### PR TITLE
Fix CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,15 +2,16 @@ name: Continuous Integration
 
 on:
   pull_request:
+  push:
     branches: 
       - main
-  push:
 
 env:
   # /opt/homebrew/opt/llvm@20/ is for macOS
   MLIR_SYS_200_PREFIX: /home/linuxbrew/.linuxbrew/opt/llvm@20/
   TABLEGEN_200_PREFIX: /home/linuxbrew/.linuxbrew/opt/llvm@20/
   RUSTFLAGS: '-L /home/linuxbrew/.linuxbrew/opt/llvm@20/lib'
+  LLZK_SYS_ENABLE_WHOLE_ARCHIVE: 1
 
 jobs:
   build:
@@ -18,7 +19,7 @@ jobs:
     strategy:
       matrix:
         BUILD_TARGET: 
-          # - release 
+          - release
           - dev
     steps:
       - uses: actions/checkout@v4
@@ -44,5 +45,5 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Build in "${{ matrix.BUILD_TARGET }}" mode
         run: cargo build --profile ${{ matrix.BUILD_TARGET }}
-#      - name: Run tests in "${{ matrix.BUILD_TARGET }}" mode
-#        run: cargo test --profile ${{ matrix.BUILD_TARGET }}
+      - name: Run tests in "${{ matrix.BUILD_TARGET }}" mode
+        run: cargo test --profile ${{ matrix.BUILD_TARGET }}

--- a/llzk-sys/src/build_support/default.rs
+++ b/llzk-sys/src/build_support/default.rs
@@ -3,6 +3,8 @@ use bindgen::Builder;
 use cc::Build;
 use cmake::Config;
 
+use crate::build_support::llzk::LIBDIR;
+
 use super::{
     config_traits::{BindgenConfig, CCConfig, CMakeConfig},
     mlir::MlirConfig,
@@ -28,6 +30,10 @@ impl CMakeConfig for DefaultConfig<'_> {
     fn apply(&self, cmake: &mut Config) -> Result<()> {
         cmake
             .define("LLZK_BUILD_DEVTOOLS", "OFF")
+            .define("LLZK_ENABLE_BINDINGS_PYTHON", "OFF")
+            // Force the install lib directory for consistency between Linux distros
+            // See: https://stackoverflow.com/questions/76517286/how-does-cmake-decide-to-make-a-lib-or-lib64-directory-for-installations
+            .define("CMAKE_INSTALL_LIBDIR", LIBDIR)
             .define("BUILD_TESTING", "OFF");
         CMakeConfig::apply(&self.mlir, cmake)
     }

--- a/llzk-sys/src/build_support/llzk.rs
+++ b/llzk-sys/src/build_support/llzk.rs
@@ -15,6 +15,8 @@ use crate::build_support::mlir::MlirConfig;
 
 use super::config_traits::{BindgenConfig, CCConfig, CMakeConfig};
 
+pub const LIBDIR: &str = "lib";
+
 pub struct LlzkBuild {
     path: PathBuf,
     cached_libraries: Option<(Vec<PathBuf>, Vec<String>)>,

--- a/llzk-sys/src/build_support/mod.rs
+++ b/llzk-sys/src/build_support/mod.rs
@@ -1,10 +1,12 @@
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use bindgen::Builder;
 use cc::Build;
 use compile_commands::CompileCommands;
 use config_traits::{BindgenConfig, CCConfig};
 use default::DefaultConfig;
 use llzk::LlzkBuild;
+
+use crate::build_support::llzk::LIBDIR;
 
 pub mod compile_commands;
 pub mod config_traits;
@@ -35,12 +37,33 @@ fn build_llzk_inner(default_cfg: &DefaultConfig) -> Result<LlzkBuild> {
 }
 
 pub fn build_llzk(default_cfg: &DefaultConfig) -> Result<LlzkBuild> {
-    let mut llzk = build_llzk_inner(default_cfg)?;
-    for path in llzk.link_paths()? {
-        println!("cargo:rustc-link-search={}", path.display());
-    }
-    for lib in llzk.library_names()? {
-        println!("cargo:rustc-link-lib={lib}");
+    let llzk = build_llzk_inner(default_cfg)?;
+    // TODO: Change the path `llzk` keeps track of to be $OUT instead of the current: $OUT/build
+    // Since the libs are actually installed in $OUT/$LIBDIR.
+    let lib_path = llzk
+        .path()
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("Failed to extract parent of {}", llzk.path().display()))?
+        .join(LIBDIR);
+    println!("cargo:rustc-link-search=native={}", lib_path.display());
+    // Adding the whole archive modifier is optional since only seems to be required for some GNU-like linkers.
+    let modifier = if std::env::var("LLZK_SYS_ENABLE_WHOLE_ARCHIVE").is_ok_and(|var| var == "1") {
+        ":+whole-archive"
+    } else {
+        ""
+    };
+    for entry in lib_path
+        .read_dir()
+        .with_context(|| format!("Failed to read directory {}", lib_path.display()))?
+    {
+        let name = entry
+            .context("Failed to read entry in directory")?
+            .file_name()
+            .into_string()
+            .map_err(|orig| anyhow::anyhow!("Failed to convert {orig:?} into a String"))?;
+        if let Some(lib) = name.strip_prefix("lib").and_then(|s| s.strip_suffix(".a")) {
+            println!("cargo:rustc-link-lib=static{modifier}={lib}");
+        }
     }
 
     Ok(llzk)


### PR DESCRIPTION
Minimal changes for fixing CI:
- CMake flags for a common installation directory
- Add possibility of adding the `--whole-archive` flag for GNU-like linkers (like CI's) to avoid removing symbols

