### PR TITLE
Remove unnecessary tools from CI image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
       - uses: Homebrew/actions/setup-homebrew@master
       - name: Cache homebrew downloads
         uses: actions/cache@v4


### PR DESCRIPTION
I noticed that building in release mode was killing CI because the image would run out of space. The build cache in release mode is quite big so hopefully removing things we don't need helps.
