### PR TITLE
Enable bulk lookup lowering

### DIFF
--- a/frontends/halo2/src/ir/groups.rs
+++ b/frontends/halo2/src/ir/groups.rs
@@ -22,7 +22,10 @@ use crate::{
         stmt::IRStmt,
         CmpOp, IRCtx,
     },
-    lookups::{callbacks::LazyLookupTableGenerator, Lookup},
+    lookups::{
+        callbacks::{LazyLookupTableGenerator, LookupTableGenerator},
+        Lookup,
+    },
     resolvers::FixedQueryResolver,
     synthesis::{
         constraint::EqConstraint,
@@ -687,100 +690,34 @@ where
     'cb: 'sco + 'syn,
     F: Field,
 {
-    let mut temps = Temps::new();
-    let mut last_comment = LookupComment::new(generate_debug_comments);
-    utils::product(syn.lookups(), region_rows)
-        .map(|(lookup, rr)| {
-            let table = LazyLookupTableGenerator::new(|| {
+    let lookups = syn.lookups();
+    let tables_sto = lookups
+        .iter()
+        .copied()
+        .map(|lookup| {
+            LazyLookupTableGenerator::new(move || {
                 syn.tables_for_lookup(&lookup)
                     .map(|table| table.into_boxed_slice())
-            });
-
-            let comment = IRStmt::seq(last_comment.get(lookup, rr));
-            lookup_cb
-                .on_lookup(lookup, &table, &mut temps)
-                .map(|stmts| {
-                    let stmts = stmts
-                        .into_iter()
-                        .map(|stmt| stmt.map(&|e| e.map(|e| ScopedExpression::from_cow(e, *rr))));
-                    prepend_comment(stmts.collect(), comment, generate_debug_comments)
-                })
+            })
         })
-        .collect()
-}
+        .collect::<Vec<_>>();
+    let tables = tables_sto
+        .iter()
+        .map(|t| -> &dyn LookupTableGenerator<F> { t })
+        .collect::<Vec<_>>();
+    let mut temps = Temps::new();
+    let ir = lookup_cb.on_lookups(&lookups, &tables, &mut temps)?;
 
-/// Helper struct that keeps track of the last emitted comment during lookup IR emission.
-struct LookupComment {
-    lookup: Option<usize>,
-    region: Option<usize>,
-    generate_debug_comments: bool,
-}
-
-impl LookupComment {
-    pub fn new(generate_debug_comments: bool) -> Self {
-        Self {
-            lookup: None,
-            region: None,
-            generate_debug_comments,
-        }
-    }
-
-    /// If the lookup and region doesn't match the current one returns the comment. Otherwise returns
-    /// None.
-    pub fn get<'sco, 'syn, 'ctx, F: Field>(
-        &mut self,
-        lookup: Lookup<'syn, F>,
-        rr: &RegionRow<'syn, 'ctx, 'syn, F>,
-    ) -> Option<IRStmt<ExprOrTemp<ScopedExpression<'syn, 'sco, F>>>> {
-        // There's no point in creating the comment if its not going to be emitted anyway.
-        if !self.generate_debug_comments {
-            return None;
-        }
-
-        let Some(region_index) = rr.region_index() else {
-            // If the region does not have an index emit the comment regardless and reset the
-            // tracker.
-            self.lookup = None;
-            self.region = None;
-            return Some(self.mk_comment(lookup, rr));
-        };
-
-        match (self.lookup, self.region) {
-            // If nothing was initialized just set it.
-            (None, None) => self.update_and_emit(lookup, rr),
-            // If we changed lookup or region we set the tracker to the new ones.
-            (Some(cur_lookup), Some(cur_region))
-                if cur_lookup != lookup.idx() || cur_region != region_index =>
-            {
-                self.update_and_emit(lookup, rr)
-            }
-            // This shouldn't happen.
-            (None, Some(_)) | (Some(_), None) => unreachable!(),
-            // If nothing above matches we don't emit the comment.
-            _ => None,
-        }
-    }
-
-    fn update_and_emit<'sco, 'syn, 'ctx, F: Field>(
-        &mut self,
-        lookup: Lookup<'syn, F>,
-        rr: &RegionRow<'syn, 'ctx, 'syn, F>,
-    ) -> Option<IRStmt<ExprOrTemp<ScopedExpression<'syn, 'sco, F>>>> {
-        self.lookup = Some(lookup.idx());
-        self.region = Some(
-            rr.region_index()
-                .expect("We already checked that the index is not None"),
-        );
-        Some(self.mk_comment(lookup, rr))
-    }
-
-    fn mk_comment<'sco, 'syn, 'ctx, F: Field>(
-        &self,
-        lookup: Lookup<'syn, F>,
-        rr: &RegionRow<'syn, 'ctx, 'syn, F>,
-    ) -> IRStmt<ExprOrTemp<ScopedExpression<'syn, 'sco, F>>> {
-        IRStmt::comment(format!("{lookup} @ {}", rr.header()))
-    }
+    Ok(region_rows
+        .iter()
+        .map(|rr| {
+            let region_ir = ir
+                .clone()
+                .map(&|e| e.map(|e| ScopedExpression::from_cow(e, *rr)));
+            let comment = IRStmt::comment(format!("Lookups @ {}", rr.header()));
+            prepend_comment(region_ir, comment, generate_debug_comments)
+        })
+        .collect())
 }
 
 /// If the given statement is not empty prepends a comment

--- a/frontends/halo2/src/lookups/callbacks.rs
+++ b/frontends/halo2/src/lookups/callbacks.rs
@@ -56,6 +56,22 @@ impl<F, FN: FnOnce() -> LookupTableBox<F>> std::fmt::Debug for LazyLookupTableGe
 
 /// Callback trait for defering to the client how to handle the logic of a lookup.
 pub trait LookupCallbacks<F: Field> {
+    /// Called on the list of lookups the circuit defines.
+    ///
+    /// By default loops over the lookups and calls [`LookupCallbacks::on_lookup`] on each.
+    fn on_lookups<'syn>(
+        &self,
+        lookups: &[Lookup<'syn, F>],
+        tables: &[&dyn LookupTableGenerator<F>],
+        temps: &mut Temps,
+    ) -> Result<IRStmt<ExprOrTemp<Cow<'syn, Expression<F>>>>> {
+        lookups
+            .iter()
+            .zip(tables.iter())
+            .map(|(lookup, table)| self.on_lookup(*lookup, *table, temps))
+            .collect()
+    }
+
     /// Called on each lookup the circuit defines.
     fn on_lookup<'syn>(
         &self,


### PR DESCRIPTION
Changes how lookups are generated to give the callback a chance of handling the lookups as a whole instead of individually.
