### PR TITLE
improve `SymbolRefAttribute` API

### DIFF
--- a/llzk/src/symbol_ref.rs
+++ b/llzk/src/symbol_ref.rs
@@ -23,28 +23,32 @@ pub struct SymbolRefAttribute<'c> {
 }
 
 impl<'c> SymbolRefAttribute<'c> {
-    /// Creates a new symbol attribute with the give name and path.
+    /// Creates a new symbol attribute with the given root and nested path symbols.
     ///
-    /// The path doesn't contain the name of the symbol. Therefore, for symbols defined at the _top
-    /// level_ the `refs` slice should be empty.
-    pub fn new(ctx: &'c Context, name: &str, refs: &[&str]) -> Self {
-        let name = StringRef::new(name);
-        let refs: Vec<_> = refs
-            .iter()
-            .map(|r| FlatSymbolRefAttribute::new(ctx, r))
-            .collect();
-        let raw_refs: Vec<_> = refs.iter().map(|r| r.to_raw()).collect();
-
+    /// For symbols defined at the _top level_ the `refs` slice should be empty.
+    pub fn new(ctx: &'c Context, root: StringRef, nested: &[impl SymbolRefAttrLike<'c>]) -> Self {
+        let raw_refs: Vec<_> = nested.iter().map(|r| r.to_raw()).collect();
         Self {
             inner: unsafe {
                 Attribute::from_raw(mlirSymbolRefAttrGet(
                     ctx.to_raw(),
-                    name.to_raw(),
+                    root.to_raw(),
                     raw_refs.len() as isize,
                     raw_refs.as_ptr(),
                 ))
             },
         }
+    }
+
+    /// Creates a new symbol attribute with the given root and nested path symbols.
+    ///
+    /// For symbols defined at the _top level_ the `refs` slice should be empty.
+    pub fn new_from_str(ctx: &'c Context, root: &str, nested: &[&str]) -> Self {
+        let refs: Vec<_> = nested
+            .iter()
+            .map(|r| FlatSymbolRefAttribute::new(ctx, r))
+            .collect();
+        Self::new(ctx, StringRef::new(root), &refs)
     }
 
     /// Returns the root of the symbol's path.
@@ -57,12 +61,17 @@ impl<'c> SymbolRefAttribute<'c> {
         unsafe { StringRef::from_raw(mlirSymbolRefAttrGetLeafReference(self.to_raw())) }
     }
 
-    /// Returns the symbol path as a vector of independent attributes.
-    pub fn nested(&self) -> Vec<Attribute<'c>> {
+    /// Returns the symbol path, excluding the root, as a vector of independent attributes.
+    pub fn nested(&self) -> Vec<FlatSymbolRefAttribute<'c>> {
         let nested_count = unsafe { mlirSymbolRefAttrGetNumNestedReferences(self.to_raw()) };
         (0..nested_count)
-            .map(|i| unsafe {
-                Attribute::from_raw(mlirSymbolRefAttrGetNestedReference(self.to_raw(), i))
+            .map(|i| {
+                unsafe {
+                    // TODO: return as FlatSymREfAttribute instead of generic Attribute,
+                    Attribute::from_raw(mlirSymbolRefAttrGetNestedReference(self.to_raw(), i))
+                }
+                .try_into()
+                .expect("expected FlatSymbolRefAttribute")
             })
             .collect()
     }

--- a/llzk/tests/function_dialect.rs
+++ b/llzk/tests/function_dialect.rs
@@ -176,7 +176,7 @@ fn call_op_self_value_of_compute() {
     let builder = OpBuilder::at_block_begin(&context, s2_compute_body);
     let loc = Location::unknown(&context);
     let call = builder.insert(loc, |_, loc| {
-        let name = SymbolRefAttribute::new(&context, "StructA", &["compute"]);
+        let name = SymbolRefAttribute::new_from_str(&context, "StructA", &["compute"]);
         dialect::function::call(&builder, loc, name, &[], &[s1.r#type()])
             .unwrap()
             .into()

--- a/llzk/tests/poly_dialect.rs
+++ b/llzk/tests/poly_dialect.rs
@@ -142,7 +142,7 @@ fn empty_struct_with_one_param() {
     let module = llzk_module(Location::unknown(&context));
     let loc = Location::unknown(&context);
     let typ = StructType::new(
-        SymbolRefAttribute::new(&context, "tmpl", &["empty"]),
+        SymbolRefAttribute::new_from_str(&context, "tmpl", &["empty"]),
         &[FlatSymbolRefAttribute::new(&context, "T").into()],
     );
 

--- a/llzk/tests/struct_dialect.rs
+++ b/llzk/tests/struct_dialect.rs
@@ -26,7 +26,7 @@ fn struct_type_with_flat_name() {
 fn struct_type_with_non_flat_name() {
     common::setup();
     let context = LlzkContext::new();
-    let a = SymbolRefAttribute::new(&context, "root", &["a", "b"]);
+    let a = SymbolRefAttribute::new_from_str(&context, "root", &["a", "b"]);
     let typ = StructType::new(a, &[]);
     assert_eq!(typ.name(), a);
 }

--- a/llzk/tests/symbol_ref.rs
+++ b/llzk/tests/symbol_ref.rs
@@ -1,0 +1,19 @@
+use llzk::prelude::*;
+
+mod common;
+
+#[test]
+fn append_sym_attr() {
+    common::setup();
+    let context = LlzkContext::new();
+    let base = SymbolRefAttribute::new_from_str(&context, "R", &["A", "B", "C"]);
+    let append = "D";
+
+    let mut tail = base.nested();
+    tail.push(FlatSymbolRefAttribute::new(&context, append).into());
+    let result = SymbolRefAttribute::new(&context, base.root(), &tail);
+
+    let ir = format!("{result}");
+    let expected = "@R::@A::@B::@C::@D";
+    assert_eq!(ir, expected);
+}


### PR DESCRIPTION
Use more specific types and add functions to support the use case of appending a `SymbolRefAttribute`