### PR TITLE
Release llzk-sys 20.0.0 and llzk 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "llzk"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "llzk-macro",
  "llzk-sys",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "llzk-sys"
-version = "10.0.1"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "llzk-sys-build-support",

--- a/llzk-sys/Cargo.toml
+++ b/llzk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llzk-sys"
-version = "10.0.1"
+version = "20.0.0"
 edition = "2024"
 keywords = ["llzk", "mlir"]
 categories = ["external-ffi-bindings"]

--- a/llzk/Cargo.toml
+++ b/llzk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llzk"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 keywords = ["llzk", "mlir"]
 categories = ["api-bindings"]
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-llzk-sys = { path = "../llzk-sys/", version = "10"}
+llzk-sys = { path = "../llzk-sys/", version = "20"}
 llzk-macro = { path = "../llzk-macro", version = "0.3"}
 melior = { workspace = true }
 melior-macro = { workspace = true }


### PR DESCRIPTION
*Note:* The code actually pushed to crates.io corresponds to the code at `29367ba75d5b14ed9fb9d712117c8829740955e9`. Any additions to the `llzk` crate after that are not included and we may have to make another release of `llzk` for those.