### PR TITLE
Allow creating `xRef` directly from `x`

### DIFF
--- a/llzk/src/macros.rs
+++ b/llzk/src/macros.rs
@@ -167,6 +167,12 @@ macro_rules! llzk_op_type {
                 }
             }
 
+            impl<'c, 'a> From<&'a [<$type>]<'c>> for [<$type Ref>]<'c, 'a> {
+                fn from(op: &'a [<$type>]<'c>) -> Self {
+                    unsafe { Self::from_raw(op.to_raw()) }
+                }
+            }
+
             impl<'a, 'c: 'a> melior::ir::operation::OperationLike<'c, 'a> for [<$type Ref>]<'c, 'a> {
                 fn to_raw(&self) -> mlir_sys::MlirOperation {
                     self.raw

--- a/llzk/tests/function_dialect.rs
+++ b/llzk/tests/function_dialect.rs
@@ -245,3 +245,50 @@ fn call_op_self_value_of_compute() {
         "%0 = function.call @StructA::@compute() : () -> !struct.type<@StructA> "
     );
 }
+
+#[test]
+fn func_def_op_ref_from_borrow_equals_original() {
+    common::setup();
+    let context = LlzkContext::new();
+    let loc = Location::unknown(&context);
+
+    let op = dialect::function::def(
+        loc,
+        "my_func",
+        FunctionType::new(&context, &[], &[]),
+        &[],
+        None,
+    )
+    .unwrap();
+
+    // Convert a shared borrow into a FuncDefOpRef
+    let op_ref = FuncDefOpRef::from(&op);
+
+    // The ref must point to the same underlying operation.
+    assert_eq!(op_ref, op);
+}
+
+#[test]
+fn func_def_op_ref_from_borrow_does_not_drop_original() {
+    common::setup();
+    let context = LlzkContext::new();
+    let loc = Location::unknown(&context);
+
+    let op = dialect::function::def(
+        loc,
+        "my_func",
+        FunctionType::new(&context, &[], &[]),
+        &[],
+        None,
+    )
+    .unwrap();
+
+    {
+        let op_ref = FuncDefOpRef::from(&op);
+        // Use the ref so it isn't optimized away.
+        assert_eq!(op_ref.region_count(), 1);
+    } // `op_ref` drops here — `op` must still be alive.
+
+    // `op` is still valid: its Drop will run mlirOperationDestroy exactly once.
+    assert_eq!(op.region_count(), 1);
+}


### PR DESCRIPTION
The lack of this has been annoying me. Previously the only means was via append/insert the op which has obvious side effects.