### PR TITLE
Some cleanup/helper additions

### DIFF
--- a/llzk/src/dialect/function/attrs.rs
+++ b/llzk/src/dialect/function/attrs.rs
@@ -11,3 +11,11 @@ pub fn arg_name_attr<'c>(context: &'c Context, name: &str) -> NamedAttribute<'c>
         StringAttribute::new(context, name).into(),
     )
 }
+
+/// Creates a `function.res_name` named attribute.
+pub fn res_name_attr<'c>(context: &'c Context, name: &str) -> NamedAttribute<'c> {
+    (
+        Identifier::new(context, "function.res_name"),
+        StringAttribute::new(context, name).into(),
+    )
+}

--- a/llzk/src/dialect/function/mod.rs
+++ b/llzk/src/dialect/function/mod.rs
@@ -6,6 +6,7 @@ mod ops;
 use llzk_sys::mlirGetDialectHandle__llzk__function__;
 use melior::dialect::DialectHandle;
 pub use attrs::arg_name_attr;
+pub use attrs::res_name_attr;
 pub use ops::{
     CallOp, CallOpLike, CallOpRef, FuncDefOp, FuncDefOpLike, FuncDefOpMutLike, FuncDefOpRef,
 };
@@ -19,7 +20,7 @@ pub fn handle() -> DialectHandle {
 
 /// Exports the common types of the func dialect.
 pub mod prelude {
-    pub use super::attrs::arg_name_attr;
+    pub use super::attrs::{arg_name_attr, res_name_attr};
     pub use super::ops::{
         CallOp, CallOpLike, CallOpRef, CallOpRefMut, FuncDefOp, FuncDefOpLike, FuncDefOpRef,
         FuncDefOpRefMut,

--- a/llzk/src/dialect/function/mod.rs
+++ b/llzk/src/dialect/function/mod.rs
@@ -3,10 +3,10 @@
 mod attrs;
 mod ops;
 
-use llzk_sys::mlirGetDialectHandle__llzk__function__;
-use melior::dialect::DialectHandle;
 pub use attrs::arg_name_attr;
 pub use attrs::res_name_attr;
+use llzk_sys::mlirGetDialectHandle__llzk__function__;
+use melior::dialect::DialectHandle;
 pub use ops::{
     CallOp, CallOpLike, CallOpRef, FuncDefOp, FuncDefOpLike, FuncDefOpMutLike, FuncDefOpRef,
 };

--- a/llzk/src/dialect/function/ops.rs
+++ b/llzk/src/dialect/function/ops.rs
@@ -177,7 +177,7 @@ pub trait FuncDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
 
     /// Returns the n-th argument of the function.
     fn argument(&self, idx: usize) -> Result<BlockArgument<'c, 'a>, Error> {
-        self.get_body()
+        self.body()
             .and_then(|region| {
                 region
                     .first_block()
@@ -204,7 +204,7 @@ pub trait FuncDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     }
 
     ///  Gets the [FunctionType] attribute.
-    fn get_function_type(&self) -> Result<FunctionType<'c>, Error> {
+    fn function_type(&self) -> Result<FunctionType<'c>, Error> {
         let attr =
             unsafe { Attribute::from_raw(llzkFunction_FuncDefOpGetFunctionType(self.to_raw())) };
         let type_attr: TypeAttribute<'c> = attr.try_into()?;
@@ -219,7 +219,7 @@ pub trait FuncDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     }
 
     /// Returns the sym_name attribute.
-    fn get_sym_name(&self) -> Result<StringAttribute<'c>, Error> {
+    fn sym_name(&self) -> Result<StringAttribute<'c>, Error> {
         let attr = unsafe { Attribute::from_raw(llzkFunction_FuncDefOpGetSymName(self.to_raw())) };
         attr.try_into().map_err(Error::Melior)
     }
@@ -235,7 +235,7 @@ pub trait FuncDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     }
 
     /// Returns the body region of the function.
-    fn get_body(&self) -> Result<RegionRef<'c, 'a>, Error> {
+    fn body(&self) -> Result<RegionRef<'c, 'a>, Error> {
         let raw = unsafe { llzkFunction_FuncDefOpGetBody(self.to_raw()) };
         if raw.ptr.is_null() {
             Err(Error::GeneralError(
@@ -367,7 +367,7 @@ pub trait CallOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     }
 
     /// Returns the callee attribute.
-    fn get_callee(&self) -> Result<SymbolRefAttribute<'c>, Error> {
+    fn callee(&self) -> Result<SymbolRefAttribute<'c>, Error> {
         let a: Attribute<'_> =
             unsafe { Attribute::from_raw(llzkFunction_CallOpGetCallee(self.to_raw())) };
         a.try_into().map_err(Error::Melior)
@@ -379,7 +379,7 @@ pub trait CallOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     }
 
     /// Returns the template params attribute.
-    fn get_template_params(&self) -> Result<Option<ArrayAttribute<'c>>, Error> {
+    fn template_params(&self) -> Result<Option<ArrayAttribute<'c>>, Error> {
         let raw = unsafe { llzkFunction_CallOpGetTemplateParams(self.to_raw()) };
         if raw.ptr.is_null() {
             Ok(None)

--- a/llzk/src/dialect/struct/ops.rs
+++ b/llzk/src/dialect/struct/ops.rs
@@ -130,12 +130,12 @@ pub trait StructDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
         }
     }
 
-    /// Fills the given array with the MemberDefOp operations inside this struct.
+    /// Returns a vector of MemberDefOp operations inside this struct.
     ///
     /// # Panics
     ///
     /// If any of the result operations is not a `struct.member` op.
-    fn get_member_defs(&self) -> Vec<MemberDefOpRef<'c, '_>> {
+    fn member_defs(&self) -> Vec<MemberDefOpRef<'c, 'a>> {
         let num_members =
             usize::try_from(unsafe { llzkStruct_StructDefOpGetNumMemberDefs(self.to_raw()) })
                 .unwrap();
@@ -165,7 +165,7 @@ pub trait StructDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     /// # Panics
     ///
     /// If the result operation is not a `function.def`.
-    fn get_compute_func<'b>(&self) -> Option<FuncDefOpRef<'c, 'b>> {
+    fn compute_func<'b>(&self) -> Option<FuncDefOpRef<'c, 'b>> {
         let raw_op = unsafe { llzkStruct_StructDefOpGetComputeFuncOp(self.to_raw()) };
         if raw_op.ptr.is_null() {
             return None;
@@ -183,7 +183,7 @@ pub trait StructDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     /// # Panics
     ///
     /// If the result operation is not a `function.def`.
-    fn get_constrain_func<'b>(&self) -> Option<FuncDefOpRef<'c, 'b>> {
+    fn constrain_func<'b>(&self) -> Option<FuncDefOpRef<'c, 'b>> {
         let raw_op = unsafe { llzkStruct_StructDefOpGetConstrainFuncOp(self.to_raw()) };
         if raw_op.ptr.is_null() {
             return None;
@@ -197,7 +197,7 @@ pub trait StructDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
 
     /// Returns the names of all template parameters accessible by the struct,
     /// if the struct is within a template op. Otherwise, returns an empty vec.
-    fn get_template_param_op_names(&self) -> Vec<FlatSymbolRefAttribute<'c>> {
+    fn template_param_op_names(&self) -> Vec<FlatSymbolRefAttribute<'c>> {
         let num_attrs = usize::try_from(unsafe {
             llzkStruct_StructDefOpGetNumTemplateParamOpNames(self.to_raw())
         })
@@ -217,7 +217,7 @@ pub trait StructDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
 
     /// Returns the names of all template expressions accessible by the struct,
     /// if the struct is within a template op. Otherwise, returns an empty vec.
-    fn get_template_expr_op_names(&self) -> Vec<FlatSymbolRefAttribute<'c>> {
+    fn template_expr_op_names(&self) -> Vec<FlatSymbolRefAttribute<'c>> {
         let num_attrs = usize::try_from(unsafe {
             llzkStruct_StructDefOpGetNumTemplateExprOpNames(self.to_raw())
         })
@@ -240,7 +240,7 @@ pub trait StructDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     /// # Panics
     ///
     /// If the fully qualified name is not a [`SymbolRefAttribute`].
-    fn get_fully_qualified_name(&self) -> SymbolRefAttribute<'c> {
+    fn fully_qualified_name(&self) -> SymbolRefAttribute<'c> {
         unsafe { Attribute::from_raw(llzkStruct_StructDefOpGetFullyQualifiedName(self.to_raw())) }
             .try_into()
             .expect("symbol ref attribute")

--- a/llzk/src/dialect/verif/ops.rs
+++ b/llzk/src/dialect/verif/ops.rs
@@ -182,14 +182,13 @@ mod include_op_ext {
 
 pub use include_op_ext::IncludeArgOperandsIter;
 
+#[inline]
 fn create_out_of_bounds_error<'c: 'a, 'a>(
     contract: &(impl ContractOpLike<'c, 'a> + ?Sized),
     idx: usize,
 ) -> Error {
-    match SymbolRefAttribute::try_from(contract.fully_qualified_name()) {
-        Ok(fqn) => Error::OutOfBoundsArgument(Some(fqn.to_string()), idx),
-        Err(err) => err.into(),
-    }
+    let fqn = contract.fully_qualified_name();
+    Error::OutOfBoundsArgument(Some(fqn.to_string()), idx)
 }
 
 //===----------------------------------------------------------------------===//

--- a/llzk/src/dialect/verif/ops.rs
+++ b/llzk/src/dialect/verif/ops.rs
@@ -29,12 +29,12 @@ use llzk_sys::{
     llzkVerif_RequireConstrainOpGetCondition, llzkVerif_RequireConstrainOpSetCondition,
 };
 use melior::ir::{
-        Attribute, AttributeLike, BlockLike as _, Identifier, Location, Operation, OperationRef,
-        RegionLike as _, RegionRef, Type, ValueLike as _,
-        attribute::{DenseI32ArrayAttribute, StringAttribute, TypeAttribute},
-        block::{Block, BlockArgument},
-        operation::OperationLike,
-        r#type::FunctionType,
+    Attribute, AttributeLike, BlockLike as _, Identifier, Location, Operation, OperationRef,
+    RegionLike as _, RegionRef, Type, ValueLike as _,
+    attribute::{DenseI32ArrayAttribute, StringAttribute, TypeAttribute},
+    block::{Block, BlockArgument},
+    operation::OperationLike,
+    r#type::FunctionType,
 };
 
 use crate::{
@@ -303,7 +303,9 @@ pub trait ContractOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
                 self.to_raw(),
                 false,
             ))
-        }.try_into().expect("symbol ref attribute")
+        }
+        .try_into()
+        .expect("symbol ref attribute")
     }
 
     /// Returns the n-th argument of the contract.
@@ -455,9 +457,7 @@ pub trait IncludeOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
         if raw.ptr.is_null() {
             Ok(None)
         } else {
-            Ok(Some(
-                unsafe { Attribute::from_raw(raw) }.try_into()?,
-            ))
+            Ok(Some(unsafe { Attribute::from_raw(raw) }.try_into()?))
         }
     }
 

--- a/llzk/src/map_operands.rs
+++ b/llzk/src/map_operands.rs
@@ -99,10 +99,7 @@ impl MapOperandsBuilder {
     }
 
     /// Returns the dimensions as an attribute.
-    pub fn dims_per_map_attr<'ctx>(
-        &self,
-        context: &'ctx Context,
-    ) -> DenseI32ArrayAttribute<'ctx> {
+    pub fn dims_per_map_attr<'ctx>(&self, context: &'ctx Context) -> DenseI32ArrayAttribute<'ctx> {
         DenseI32ArrayAttribute::try_from(unsafe {
             Attribute::from_option_raw(llzkAffineMapOperandsBuilderGetDimsPerMapAttr(
                 self.raw,

--- a/llzk/src/map_operands.rs
+++ b/llzk/src/map_operands.rs
@@ -99,7 +99,7 @@ impl MapOperandsBuilder {
     }
 
     /// Returns the dimensions as an attribute.
-    pub fn get_dims_per_map_attr<'ctx>(
+    pub fn dims_per_map_attr<'ctx>(
         &self,
         context: &'ctx Context,
     ) -> DenseI32ArrayAttribute<'ctx> {

--- a/llzk/src/prelude.rs
+++ b/llzk/src/prelude.rs
@@ -69,7 +69,8 @@ pub mod dialect {
     /// Exports functions from the 'function' dialect
     pub mod function {
         pub use crate::dialect::function::{
-            arg_name_attr, call, call_with_map_operands, call_with_template_params, def, r#return,
+            arg_name_attr, call, call_with_map_operands, call_with_template_params, def,
+            r#return, res_name_attr,
         };
         pub use crate::dialect::function::{is_func_call, is_func_def, is_func_return};
     }

--- a/llzk/src/prelude.rs
+++ b/llzk/src/prelude.rs
@@ -70,7 +70,7 @@ pub mod dialect {
     pub mod function {
         pub use crate::dialect::function::{
             arg_name_attr, call, call_with_map_operands, call_with_template_params, def,
-            r#return, res_name_attr,
+            res_name_attr, r#return,
         };
         pub use crate::dialect::function::{is_func_call, is_func_def, is_func_return};
     }

--- a/llzk/src/symbol_lookup.rs
+++ b/llzk/src/symbol_lookup.rs
@@ -29,7 +29,7 @@ impl<'ctx> SymbolLookupResult<'ctx> {
     }
 
     /// Returns a reference to the operation obtained from the lookup.
-    pub fn get_operation<'a>(&'a self) -> Option<OperationRef<'ctx, 'a>> {
+    pub fn operation<'a>(&'a self) -> Option<OperationRef<'ctx, 'a>> {
         unsafe {
             OperationRef::from_option_raw(llzk_sys::LlzkSymbolLookupResultGetOperation(self.raw))
         }

--- a/llzk/tests/function_dialect.rs
+++ b/llzk/tests/function_dialect.rs
@@ -159,9 +159,7 @@ fn func_def_op_self_value_of_compute() {
     llzk::operation::verify_operation_with_diags(&s).expect("verification failed");
     log::info!("Struct passed verification");
 
-    let compute_fn = s
-        .compute_func()
-        .expect("failed to get compute function");
+    let compute_fn = s.compute_func().expect("failed to get compute function");
     let self_val = compute_fn.self_value_of_compute().unwrap();
     // Get the expected value. The first operation in the compute function is
     // the CreateStructOp, whose first result is the self value.
@@ -539,10 +537,7 @@ fn call_op_set_callee() {
     let loc = Location::unknown(&context);
     let block = Block::new(&[]);
     let call = make_call_op_in_block(&context, loc, &block, &[]);
-    assert_eq!(
-        call.callee().unwrap().root().as_str().unwrap(),
-        "callee"
-    );
+    assert_eq!(call.callee().unwrap().root().as_str().unwrap(), "callee");
     call.set_callee(SymbolRefAttribute::new_from_str(
         &context,
         "new_callee",

--- a/llzk/tests/function_dialect.rs
+++ b/llzk/tests/function_dialect.rs
@@ -160,7 +160,7 @@ fn func_def_op_self_value_of_compute() {
     log::info!("Struct passed verification");
 
     let compute_fn = s
-        .get_compute_func()
+        .compute_func()
         .expect("failed to get compute function");
     let self_val = compute_fn.self_value_of_compute().unwrap();
     // Get the expected value. The first operation in the compute function is
@@ -191,7 +191,7 @@ fn func_def_op_self_value_of_constrain() {
     log::info!("Struct passed verification");
 
     let constrain_fn = s
-        .get_constrain_func()
+        .constrain_func()
         .expect("failed to get constrain function");
     let self_val = constrain_fn.self_value_of_constrain().unwrap();
     // Get the expected value. The first argument of the function is the self value.
@@ -220,7 +220,7 @@ fn call_op_self_value_of_compute() {
     log::info!("Struct 2 passed verification");
 
     let s2_compute_body = s2
-        .get_compute_func()
+        .compute_func()
         .expect("failed to get compute function")
         .region(0)
         .expect("failed to get first region")
@@ -310,7 +310,7 @@ fn func_def_op_get_function_type() {
         None,
     )
     .unwrap();
-    let result = op.get_function_type().unwrap();
+    let result = op.function_type().unwrap();
     assert_eq!(result.input_count(), 1);
     assert_eq!(result.result_count(), 0);
 }
@@ -329,9 +329,9 @@ fn func_def_op_set_function_type() {
         None,
     )
     .unwrap();
-    assert_eq!(op.get_function_type().unwrap().input_count(), 0);
+    assert_eq!(op.function_type().unwrap().input_count(), 0);
     op.set_function_type(FunctionType::new(&context, &[felt_type], &[]));
-    assert_eq!(op.get_function_type().unwrap().input_count(), 1);
+    assert_eq!(op.function_type().unwrap().input_count(), 1);
 }
 
 #[test]
@@ -347,7 +347,7 @@ fn func_def_op_get_sym_name() {
         None,
     )
     .unwrap();
-    assert_eq!(op.get_sym_name().unwrap().value(), "my_func");
+    assert_eq!(op.sym_name().unwrap().value(), "my_func");
 }
 
 #[test]
@@ -363,9 +363,9 @@ fn func_def_op_set_sym_name() {
         None,
     )
     .unwrap();
-    assert_eq!(op.get_sym_name().unwrap().value(), "my_func");
+    assert_eq!(op.sym_name().unwrap().value(), "my_func");
     op.set_sym_name(StringAttribute::new(&context, "new_name"));
-    assert_eq!(op.get_sym_name().unwrap().value(), "new_name");
+    assert_eq!(op.sym_name().unwrap().value(), "new_name");
 }
 
 #[test]
@@ -407,7 +407,7 @@ fn func_def_op_get_body() {
     )
     .unwrap();
     // A freshly created FuncDefOp already has a (empty) region; get_body returns Ok.
-    assert!(op.get_body().is_ok());
+    assert!(op.body().is_ok());
 
     // After appending a block, get_body still succeeds.
     let block = Block::new(&[]);
@@ -415,7 +415,7 @@ fn func_def_op_get_body() {
     op.region(0)
         .expect("function.def must have at least 1 region")
         .append_block(block);
-    assert!(op.get_body().is_ok());
+    assert!(op.body().is_ok());
 }
 
 // Tests for CallOpLike methods added in e2157c6
@@ -528,7 +528,7 @@ fn call_op_get_callee() {
     let loc = Location::unknown(&context);
     let block = Block::new(&[]);
     let call = make_call_op_in_block(&context, loc, &block, &[]);
-    let callee = call.get_callee().unwrap();
+    let callee = call.callee().unwrap();
     assert_eq!(callee.root().as_str().unwrap(), "callee");
 }
 
@@ -540,7 +540,7 @@ fn call_op_set_callee() {
     let block = Block::new(&[]);
     let call = make_call_op_in_block(&context, loc, &block, &[]);
     assert_eq!(
-        call.get_callee().unwrap().root().as_str().unwrap(),
+        call.callee().unwrap().root().as_str().unwrap(),
         "callee"
     );
     call.set_callee(SymbolRefAttribute::new_from_str(
@@ -549,7 +549,7 @@ fn call_op_set_callee() {
         &[],
     ));
     assert_eq!(
-        call.get_callee().unwrap().root().as_str().unwrap(),
+        call.callee().unwrap().root().as_str().unwrap(),
         "new_callee"
     );
 }
@@ -561,7 +561,7 @@ fn call_op_get_template_params_none() {
     let loc = Location::unknown(&context);
     let block = Block::new(&[]);
     let call = make_call_op_in_block(&context, loc, &block, &[]);
-    assert!(call.get_template_params().unwrap().is_none());
+    assert!(call.template_params().unwrap().is_none());
 }
 
 #[test]
@@ -571,13 +571,13 @@ fn call_op_set_template_params() {
     let loc = Location::unknown(&context);
     let block = Block::new(&[]);
     let call = make_call_op_in_block(&context, loc, &block, &[]);
-    assert!(call.get_template_params().unwrap().is_none());
+    assert!(call.template_params().unwrap().is_none());
     // Set a non-None value.
     call.set_template_params(Some(ArrayAttribute::new(&context, &[])));
-    assert!(call.get_template_params().unwrap().is_some());
+    assert!(call.template_params().unwrap().is_some());
     // Clear back to None.
     call.set_template_params(None);
-    assert!(call.get_template_params().unwrap().is_none());
+    assert!(call.template_params().unwrap().is_none());
 }
 
 #[test]
@@ -597,7 +597,7 @@ fn call_with_template_params_only_attrs() {
         &[TypeAttribute::new(felt_type)],
     )
     .unwrap();
-    let template_params = call.get_template_params().unwrap().unwrap();
+    let template_params = call.template_params().unwrap().unwrap();
     assert_eq!(template_params.len(), 1);
 }
 
@@ -625,7 +625,7 @@ fn call_with_template_params_only_args() {
     );
     let call = CallOpRef::try_from(call).unwrap();
     assert_eq!(call.arg_operand_count(), 1);
-    assert!(call.get_template_params().unwrap().is_none());
+    assert!(call.template_params().unwrap().is_none());
 }
 
 #[test]
@@ -652,5 +652,5 @@ fn call_with_template_params_no_empties() {
     );
     let call = CallOpRef::try_from(call).unwrap();
     assert_eq!(call.arg_operand_count(), 1);
-    assert!(call.get_template_params().unwrap().is_some());
+    assert!(call.template_params().unwrap().is_some());
 }

--- a/llzk/tests/struct_dialect.rs
+++ b/llzk/tests/struct_dialect.rs
@@ -64,7 +64,7 @@ fn struct_with_one_member() {
 
     let s = dialect::r#struct::def(loc, name, region_ops).unwrap();
     assert!(s.get_member_def("foo").is_some());
-    assert_eq!(s.get_member_defs().len(), 1);
+    assert_eq!(s.member_defs().len(), 1);
     let s = module.body().append_operation(s.into());
 
     assert_test!(s, module, @file "expected/struct_with_one_member.mlir");
@@ -124,7 +124,7 @@ fn struct_readm() {
     let s = StructDefOpRef::try_from(module.body().append_operation(s.into())).unwrap();
 
     let constrain_body = s
-        .get_constrain_func()
+        .constrain_func()
         .expect("failed to get constrain function")
         .region(0)
         .expect("failed to get first region")

--- a/llzk/tests/verif_dialect.rs
+++ b/llzk/tests/verif_dialect.rs
@@ -42,14 +42,8 @@ fn make_zero_arg_function_target<'c>(
     name: &str,
 ) -> FuncDefOpRef<'c, 'c> {
     let loc = Location::unknown(context);
-    let func = dialect::function::def(
-        loc,
-        name,
-        FunctionType::new(context, &[], &[]),
-        &[],
-        None,
-    )
-    .unwrap();
+    let func =
+        dialect::function::def(loc, name, FunctionType::new(context, &[], &[]), &[], None).unwrap();
     {
         let block = Block::new(&[]);
         block.append_operation(dialect::function::r#return(loc, &[]));
@@ -115,8 +109,14 @@ fn contract_from_function_target() {
     assert!(contract.has_arg_name(0));
     let collected = contract.inputs().collect::<Vec<_>>();
     assert_eq!(collected.len(), 2);
-    assert_eq!(Value::from(collected[0]), Value::from(contract.argument(0).unwrap()));
-    assert_eq!(Value::from(collected[1]), Value::from(contract.argument(1).unwrap()));
+    assert_eq!(
+        Value::from(collected[0]),
+        Value::from(contract.argument(0).unwrap())
+    );
+    assert_eq!(
+        Value::from(collected[1]),
+        Value::from(contract.argument(1).unwrap())
+    );
     let mut iter = contract.inputs();
     assert_eq!(iter.len(), 2);
     assert_eq!(
@@ -170,8 +170,14 @@ fn contract_from_struct_target() {
     assert!(contract.arg_is_pub(1));
     let collected = contract.inputs().collect::<Vec<_>>();
     assert_eq!(collected.len(), 2);
-    assert_eq!(Value::from(collected[0]), Value::from(contract.argument(0).unwrap()));
-    assert_eq!(Value::from(collected[1]), Value::from(contract.argument(1).unwrap()));
+    assert_eq!(
+        Value::from(collected[0]),
+        Value::from(contract.argument(0).unwrap())
+    );
+    assert_eq!(
+        Value::from(collected[1]),
+        Value::from(contract.argument(1).unwrap())
+    );
     let mut iter = contract.inputs();
     assert_eq!(
         Value::from(iter.next_back().unwrap()),

--- a/llzk/tests/verif_dialect.rs
+++ b/llzk/tests/verif_dialect.rs
@@ -260,6 +260,17 @@ fn function_arg_name_attr_helper() {
 }
 
 #[test]
+fn function_res_name_attr_helper() {
+    common::setup();
+    let context = LlzkContext::new();
+    let (identifier, attr) = dialect::function::res_name_attr(&context, "output");
+
+    assert_eq!(identifier, Identifier::new(&context, "function.res_name"));
+    let attr = StringAttribute::try_from(attr).unwrap();
+    assert_eq!(attr.value(), "output");
+}
+
+#[test]
 fn include_with_map_operands_empty_groups() {
     common::setup();
     let context = LlzkContext::new();


### PR DESCRIPTION
- Add `function.res_name` helper
- Remove the `get_*` prefixes from simple getters
- Apply `cargo fmt` and `cargo clippy` suggestions

Closes #212