### PR TITLE
Release llzk-sys 30.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "llzk-sys"
-version = "30.0.0"
+version = "30.1.0"
 dependencies = [
  "anyhow",
  "llzk-sys-build-support",

--- a/llzk-sys/Cargo.toml
+++ b/llzk-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llzk-sys"
-version = "30.0.0"
+version = "30.1.0"
 edition = "2024"
 keywords = ["llzk", "mlir"]
 categories = ["external-ffi-bindings"]


### PR DESCRIPTION
Because there were some changes on `llzk-sys` that I missed and didn't notice until I tried to package and publish `llzk`.
