### PR TITLE
replace `OperationBuilder` with direct CAPI calls

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "release-helpers": "release-helpers"
       },
       "locked": {
-        "lastModified": 1784247001,
-        "narHash": "sha256-JLz25bhmRhTg4YmlewDnrEYqm6T0YWnl6JcNHup6W04=",
+        "lastModified": 1784305772,
+        "narHash": "sha256-x0rHHooZz8XJgwr9PDDcrk/f09xOhIGoDNwwY8CA8jg=",
         "owner": "project-llzk",
         "repo": "llzk-lib",
-        "rev": "d973c09f9e9f278cd163a22ada2cd02f8983e580",
+        "rev": "dc3a227dfbcedf10b16409c5bc345672aa7178f4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "release-helpers": "release-helpers"
       },
       "locked": {
-        "lastModified": 1784305772,
-        "narHash": "sha256-x0rHHooZz8XJgwr9PDDcrk/f09xOhIGoDNwwY8CA8jg=",
+        "lastModified": 1784311875,
+        "narHash": "sha256-cxjN54ftwR1vpkgmvvt9tjSyHK+7loctLEL0hWw7DqM=",
         "owner": "project-llzk",
         "repo": "llzk-lib",
-        "rev": "dc3a227dfbcedf10b16409c5bc345672aa7178f4",
+        "rev": "fbe3cb16f03a734b9d2adca517c63e8d5145b9ab",
         "type": "github"
       },
       "original": {

--- a/llzk-sys/src/sanity_tests/dialect/boolean.rs
+++ b/llzk-sys/src/sanity_tests/dialect/boolean.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use mlir_sys::mlirUnitAttrGet;
 use rstest::rstest;
-use std::ptr::null;
 
 #[test]
 fn test_mlir_get_dialect_handle_llzk_boolean() {
@@ -29,7 +28,7 @@ fn test_llzk_felt_cmp_predicate_attr_get(
 ) {
     unsafe {
         let attr = llzkBool_FeltCmpPredicateAttrGet(context.ctx, cmp);
-        assert_ne!(attr.ptr, null());
+        assert_ne!(attr.ptr, std::ptr::null());
     }
 }
 

--- a/llzk-sys/src/sanity_tests/dialect/felt.rs
+++ b/llzk-sys/src/sanity_tests/dialect/felt.rs
@@ -1,7 +1,6 @@
-use std::ptr::null;
-
 use mlir_sys::{mlirIndexTypeGet, mlirIntegerAttrGet};
 use rstest::rstest;
+use std::ptr::null;
 
 use crate::{
     llzkAttributeIsA_Felt_FeltConstAttr, llzkFelt_FeltConstAttrGetFromPartsUnspecified,

--- a/llzk-sys/src/sanity_tests/dialect/function.rs
+++ b/llzk-sys/src/sanity_tests/dialect/function.rs
@@ -8,7 +8,7 @@ use crate::{
     llzkFunction_CallOpCalleeIsProduct, llzkFunction_CallOpCalleeIsStructCompute,
     llzkFunction_CallOpCalleeIsStructConstrain, llzkFunction_CallOpCalleeIsStructProduct,
     llzkFunction_CallOpGetSingleResultTypeOfCompute, llzkFunction_CallOpGetTypeSignature,
-    llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs, llzkFunction_FuncDefOpGetArgNameAttr,
+    llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs, llzkFunction_FuncDefOpGetArgNameAttr,
     llzkFunction_FuncDefOpGetBody, llzkFunction_FuncDefOpGetFullyQualifiedName,
     llzkFunction_FuncDefOpGetResNameAttr, llzkFunction_FuncDefOpGetSingleResultTypeOfCompute,
     llzkFunction_FuncDefOpHasAllowConstraintAttr, llzkFunction_FuncDefOpHasAllowWitnessAttr,
@@ -62,10 +62,12 @@ fn create_func_def_op(
     arg_attrs: &[MlirAttribute],
 ) -> MlirOperation {
     unsafe {
+        let builder = mlirOpBuilderCreate(ctx);
         let location = mlirLocationUnknownGet(ctx);
         let name = CString::new(name).unwrap();
         let name = mlirStringRefCreateFromCString(name.as_ptr());
-        llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
+        let ret = llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
+            builder,
             location,
             name,
             r#type,
@@ -73,7 +75,9 @@ fn create_func_def_op(
             attrs.as_ptr(),
             isize::try_from(arg_attrs.len()).expect("arg_attrs too large"),
             arg_attrs.as_ptr(),
-        )
+        );
+        mlirOpBuilderDestroy(builder);
+        ret
     }
 }
 

--- a/llzk-sys/src/sanity_tests/dialect/global.rs
+++ b/llzk-sys/src/sanity_tests/dialect/global.rs
@@ -1,5 +1,3 @@
-use std::ptr::null_mut;
-
 use mlir_sys::{
     MlirAttribute, MlirContext, MlirNamedAttribute, MlirOperation, MlirType,
     mlirAttributeGetContext, mlirFlatSymbolRefAttrGet, mlirIdentifierGet, mlirIndexTypeGet,
@@ -8,6 +6,7 @@ use mlir_sys::{
     mlirUnitAttrGet,
 };
 use rstest::rstest;
+use std::ptr::null_mut;
 
 use crate::{
     llzkGlobal_GlobalDefOpIsConstant, llzkOperationIsA_Global_GlobalDefOp,

--- a/llzk-sys/src/sanity_tests/dialect/include.rs
+++ b/llzk-sys/src/sanity_tests/dialect/include.rs
@@ -4,7 +4,8 @@ use mlir_sys::{mlirLocationUnknownGet, mlirOperationDestroy};
 use rstest::rstest;
 
 use crate::{
-    llzkInclude_IncludeOpCreateInferredContext, mlirGetDialectHandle__llzk__include__,
+    llzkInclude_IncludeOpBuildInferredContext, mlirGetDialectHandle__llzk__include__,
+    mlirOpBuilderCreate, mlirOpBuilderDestroy,
     sanity_tests::{TestContext, context, str_ref},
 };
 
@@ -18,8 +19,10 @@ fn test_mlir_get_dialect_handle_llzk_include() {
 #[rstest]
 fn test_llzk_include_op_create(context: TestContext) {
     unsafe {
+        let builder = mlirOpBuilderCreate(context.ctx);
         let location = mlirLocationUnknownGet(context.ctx);
-        let op = llzkInclude_IncludeOpCreateInferredContext(
+        let op = llzkInclude_IncludeOpBuildInferredContext(
+            builder,
             location,
             str_ref("test"),
             str_ref("test.mlir"),
@@ -27,5 +30,6 @@ fn test_llzk_include_op_create(context: TestContext) {
 
         assert_ne!(op.ptr, null_mut());
         mlirOperationDestroy(op);
+        mlirOpBuilderDestroy(builder);
     }
 }

--- a/llzk-sys/src/sanity_tests/dialect/include.rs
+++ b/llzk-sys/src/sanity_tests/dialect/include.rs
@@ -1,12 +1,10 @@
-use std::ptr::null_mut;
-
-use mlir_sys::{mlirLocationUnknownGet, mlirOperationDestroy};
-use rstest::rstest;
-
 use crate::{
     llzkInclude_IncludeOpCreateInferredContext, mlirGetDialectHandle__llzk__include__,
     sanity_tests::{TestContext, context, str_ref},
 };
+use mlir_sys::{mlirLocationUnknownGet, mlirOperationDestroy};
+use rstest::rstest;
+use std::ptr::null_mut;
 
 #[test]
 fn test_mlir_get_dialect_handle_llzk_include() {

--- a/llzk-sys/src/sanity_tests/dialect/llzk.rs
+++ b/llzk-sys/src/sanity_tests/dialect/llzk.rs
@@ -1,11 +1,9 @@
-use std::ptr::null;
-
-use rstest::rstest;
-
 use crate::{
     llzkAttributeIsA_Llzk_PublicAttr, llzkLlzk_PublicAttrGet, mlirGetDialectHandle__llzk__,
     sanity_tests::{TestContext, context},
 };
+use rstest::rstest;
+use std::ptr::null;
 
 #[test]
 fn test_mlir_get_dialect_handle_llzk() {

--- a/llzk-sys/src/sanity_tests/dialect/polymorphic.rs
+++ b/llzk-sys/src/sanity_tests/dialect/polymorphic.rs
@@ -1,12 +1,3 @@
-use std::ptr::{null, null_mut};
-
-use mlir_sys::{
-    MlirValue, mlirAffineConstantExprGet, mlirAffineMapAttrGet, mlirAffineMapEqual,
-    mlirAffineMapGet, mlirAttributeEqual, mlirFlatSymbolRefAttrGet, mlirLocationUnknownGet,
-    mlirOperationDestroy, mlirOperationVerify, mlirStringAttrGet, mlirStringRefEqual,
-};
-use rstest::rstest;
-
 use crate::{
     MlirValueRange, llzkOperationIsA_Poly_ApplyMapOp, llzkOperationIsA_Poly_TemplateOp,
     llzkPoly_ApplyMapOpBuild, llzkPoly_ApplyMapOpBuildWithAffineExpr,
@@ -23,6 +14,13 @@ use crate::{
         str_ref,
     },
 };
+use mlir_sys::{
+    MlirValue, mlirAffineConstantExprGet, mlirAffineMapAttrGet, mlirAffineMapEqual,
+    mlirAffineMapGet, mlirAttributeEqual, mlirFlatSymbolRefAttrGet, mlirLocationUnknownGet,
+    mlirOperationDestroy, mlirOperationVerify, mlirStringAttrGet, mlirStringRefEqual,
+};
+use rstest::rstest;
+use std::ptr::{null, null_mut};
 
 #[test]
 fn test_mlir_get_dialect_handle_llzk_polymorphic() {

--- a/llzk-sys/src/sanity_tests/dialect/string.rs
+++ b/llzk-sys/src/sanity_tests/dialect/string.rs
@@ -1,12 +1,10 @@
-use std::ptr::null;
-
-use mlir_sys::mlirIndexTypeGet;
-use rstest::rstest;
-
 use crate::{
     llzkString_StringTypeGet, llzkTypeIsA_String_StringType, mlirGetDialectHandle__llzk__string__,
     sanity_tests::{TestContext, context},
 };
+use mlir_sys::mlirIndexTypeGet;
+use rstest::rstest;
+use std::ptr::null;
 
 #[test]
 fn test_mlir_get_dialect_handle_llzk_string() {

--- a/llzk/examples/division.rs
+++ b/llzk/examples/division.rs
@@ -101,7 +101,7 @@ fn gen_witness<'c, 'a>(
     input_type: Type<'c>,
     out_field_name: &str,
 ) -> Result<OperationRef<'c, 'a>> {
-    let ip = builder.save_insertion_point();
+    let _guard = builder.insertion_guard();
 
     // The inputs to the functions are public circuit inputs.
     let inputs = vec![(input_type, location); 2];
@@ -149,7 +149,6 @@ fn gen_witness<'c, 'a>(
         c.into(),
     )?;
 
-    builder.restore_insertion_point(ip);
     Ok(compute_fn.into())
 }
 
@@ -160,7 +159,7 @@ fn gen_constrain<'c, 'a>(
     input_type: Type<'c>,
     out_field_name: &str,
 ) -> Result<OperationRef<'c, 'a>> {
-    let ip = builder.save_insertion_point();
+    let _guard = builder.insertion_guard();
 
     // The inputs to the functions are public circuit inputs.
     let inputs = vec![(input_type, location); 2];
@@ -212,6 +211,5 @@ fn gen_constrain<'c, 'a>(
     let t = dialect::felt::mul(builder, location, c.into(), b.into())?.result(0)?;
     dialect::constrain::eq(builder, location, t.into(), a.into());
 
-    builder.restore_insertion_point(ip);
     Ok(constrain_fn.into())
 }

--- a/llzk/examples/division.rs
+++ b/llzk/examples/division.rs
@@ -8,7 +8,7 @@
 //!
 //! Run with: `cargo run --package llzk --example division`
 
-use std::{error::Error as StdError, result::Result as StdResult};
+use std::result::Result as StdResult;
 
 // Commonly used types are re-exported in the prelude.
 use llzk::{
@@ -16,7 +16,7 @@ use llzk::{
     prelude::*,
 };
 
-type Result<T> = StdResult<T, Box<dyn StdError>>;
+type Result<T> = StdResult<T, LlzkError>;
 
 const MAIN_STRUCT_NAME: &str = "Entry";
 
@@ -39,34 +39,50 @@ fn main() -> Result<()> {
 
     // Operations can be created with factory methods with the same name as the op they create,
     // mimicking its mnemonic (struct.def in this case).
-    let main_st = dialect::r#struct::def(location, MAIN_STRUCT_NAME, [])?;
+    let builder = OpBuilder::at_block_begin(&context, module.body());
 
     // The inputs of the main struct must be of type !felt.type (or array thereof).
     let felt_type = FeltType::new(&context);
+    let out_field_name = "c";
 
     // We store the output of the division in a data field.
     // Members can have three extra annotations: signal, column, and public.
     // The signal annotation makes the field a witness-stored constraint variable.
     // The public annotation makes the field an output of the circuit.
-    let out_field = {
+    dialect::r#struct::def(&builder, location, MAIN_STRUCT_NAME, |builder| {
         let is_signal = true;
         let is_column = false;
         let is_public = true;
-        dialect::r#struct::member(location, "c", felt_type, is_signal, is_column, is_public)?
-    };
-    let compute_fn = witness(&context, location, felt_type.into(), &out_field)?;
-    let constrain_fn = constraints(&context, location, felt_type.into(), &out_field)?;
+        dialect::r#struct::member(
+            builder,
+            location,
+            out_field_name,
+            felt_type,
+            is_signal,
+            is_column,
+            is_public,
+        )?;
+        gen_witness(
+            builder,
+            &context,
+            location,
+            felt_type.into(),
+            out_field_name,
+        )?;
+        gen_constrain(
+            builder,
+            &context,
+            location,
+            felt_type.into(),
+            out_field_name,
+        )?;
+        Ok(())
+    })?;
 
-    main_st.body().append_operation(out_field.into());
-    main_st.body().append_operation(compute_fn);
-    main_st.body().append_operation(constrain_fn);
-
-    // Now that we have filled out the struct we can add it to the module, verify it, and print it.
-    module.body().append_operation(main_st.into());
-    // For verifying and printing we need get a reference to the `builtin.module` op representing
-    // the module.
+    // Now that we have filled out the struct we can verify it and print it.
+    // For verifying and printing we need get a reference to the `builtin.module` op
+    // representing the module.
     let module_op = module.as_operation();
-
     if module_op.verify() {
         println!("{module_op}")
     } else {
@@ -76,14 +92,17 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn witness<'c>(
+fn gen_witness<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     // Context is the type used in melior to represent the MLIRContext.
     // A reference to a LlzkContext can be used as a reference to a Context.
     context: &'c Context,
     location: Location<'c>,
     input_type: Type<'c>,
-    out_field: &MemberDefOp<'c>,
-) -> Result<Operation<'c>> {
+    out_field_name: &str,
+) -> Result<OperationRef<'c, 'a>> {
+    let ip = builder.save_insertion_point();
+
     // The inputs to the functions are public circuit inputs.
     let inputs = vec![(input_type, location); 2];
     let pub_attr = [PublicAttribute::new_named_attr(context)];
@@ -92,6 +111,7 @@ fn witness<'c>(
     // The functions inside a struct need to have a particular structure. This helper creates the
     // `@compute` function with its proper structure.
     let compute_fn = dialect::r#struct::helpers::compute_fn(
+        builder,
         location,
         main_ty,
         &inputs,
@@ -105,7 +125,7 @@ fn witness<'c>(
     // We will insert it using the return op as reference so we need to get ahold of it and the
     // block that contains it.
     let (block, ret_op) = compute_fn
-        .region(0)?
+        .body()?
         .first_block()
         .and_then(|b| Some((b, b.terminator()?)))
         .unwrap();
@@ -115,32 +135,33 @@ fn witness<'c>(
     let b = block.argument(1)?;
 
     // The witness computes c = a / b
-    let c = block
-        .insert_operation_before(ret_op, dialect::felt::div(location, a.into(), b.into())?)
-        .result(0)?;
+    builder.set_insertion_point(ret_op);
+    let c = dialect::felt::div(builder, location, a.into(), b.into())?.result(0)?;
     // The result needs to be written into the output field. For that we need to get the value
     // created by `struct.new` first.
     let self_value = block.first_operation().unwrap().result(0)?;
     // Then use the `struct.writem` operation to commit the value into the field.
-    block.insert_operation_before(
-        ret_op,
-        dialect::r#struct::writem(
-            location,
-            self_value.into(),
-            out_field.member_name(),
-            c.into(),
-        )?,
-    );
+    dialect::r#struct::writem(
+        builder,
+        location,
+        self_value.into(),
+        out_field_name,
+        c.into(),
+    )?;
 
+    builder.restore_insertion_point(ip);
     Ok(compute_fn.into())
 }
 
-fn constraints<'c>(
+fn gen_constrain<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     context: &'c Context,
     location: Location<'c>,
     input_type: Type<'c>,
-    out_field: &MemberDefOp<'c>,
-) -> Result<Operation<'c>> {
+    out_field_name: &str,
+) -> Result<OperationRef<'c, 'a>> {
+    let ip = builder.save_insertion_point();
+
     // The inputs to the functions are public circuit inputs.
     let inputs = vec![(input_type, location); 2];
     let pub_attr = [PublicAttribute::new_named_attr(context)];
@@ -149,6 +170,7 @@ fn constraints<'c>(
     // The functions inside a struct need to have a particular structure. This helper creates the
     // `@constrain` function with its proper structure.
     let constrain_fn = dialect::r#struct::helpers::constrain_fn(
+        builder,
         location,
         main_ty,
         &inputs,
@@ -163,12 +185,10 @@ fn constraints<'c>(
     // Similar to how we generated the IR for `@compute` we need to put the IR before the
     // `function.return` operation.
     let (block, ret_op) = constrain_fn
-        .region(0)?
+        .body()?
         .first_block()
         .and_then(|b| Some((b, b.terminator()?)))
         .unwrap();
-
-    let builder = OpBuilder::at_block_end(context, block);
 
     // Obtain the inputs same as before but with the offsets increased by 1.
     let a = block.argument(1)?;
@@ -179,20 +199,19 @@ fn constraints<'c>(
     // And then read the witness output from the instance.
     builder.set_insertion_point(ret_op);
     let c = dialect::r#struct::readm(
-        &builder,
+        builder,
         location,
         FeltType::new(context).into(),
         self_value.into(),
-        out_field.member_name(),
+        out_field_name,
     )?
     .result(0)?;
 
     // The constraint is  c * b = a
     // We can use the `constrain.eq` operation for emitting equality constraints.
-    let t = block
-        .insert_operation_before(ret_op, dialect::felt::mul(location, c.into(), b.into())?)
-        .result(0)?;
-    block.insert_operation_before(ret_op, dialect::constrain::eq(location, t.into(), a.into()));
+    let t = dialect::felt::mul(builder, location, c.into(), b.into())?.result(0)?;
+    dialect::constrain::eq(builder, location, t.into(), a.into());
 
+    builder.restore_insertion_point(ip);
     Ok(constrain_fn.into())
 }

--- a/llzk/src/builder.rs
+++ b/llzk/src/builder.rs
@@ -1,6 +1,6 @@
 //! Types and traits for working with operation builders.
 
-use std::{marker::PhantomData, os::raw::c_void, ptr::null_mut};
+use std::{fmt, marker::PhantomData, os::raw::c_void, ptr::null_mut};
 
 use llzk_sys::{
     MlirOpBuilder, MlirOpBuilderInsertPoint, MlirOpBuilderListener, mlirOpBuilderCreate,
@@ -81,6 +81,14 @@ pub trait OpBuilderLike<'c> {
         unsafe {
             mlirOpBuilderRestoreInsertionPoint(self.to_raw(), point.to_raw());
         }
+    }
+
+    /// Returns a guard that restores the current insertion point when dropped.
+    fn insertion_guard<'a>(&self) -> InsertionGuard<'_, 'c, 'a, Self>
+    where
+        Self: Sized,
+    {
+        InsertionGuard::new(self)
     }
 
     /// Returns a reference to the block where the builder will insert operations.
@@ -344,6 +352,53 @@ impl<'ctx, 'blk> InsertPoint<'ctx, 'blk> {
     }
 }
 
+/// RAII guard that restores a builder's insertion point when dropped.
+///
+/// Moving this guard transfers responsibility for restoring the insertion point
+/// to the moved value.
+#[must_use = "the insertion point is restored when the guard is dropped"]
+pub struct InsertionGuard<'builder, 'ctx, 'blk, B>
+where
+    B: OpBuilderLike<'ctx> + ?Sized,
+{
+    builder: &'builder B,
+    point: InsertPoint<'ctx, 'blk>,
+}
+
+impl<'builder, 'ctx, 'blk, B> InsertionGuard<'builder, 'ctx, 'blk, B>
+where
+    B: OpBuilderLike<'ctx> + ?Sized,
+{
+    /// Creates a guard that restores the builder's current insertion point
+    /// when dropped.
+    pub fn new(builder: &'builder B) -> Self {
+        Self {
+            builder,
+            point: builder.save_insertion_point(),
+        }
+    }
+}
+
+impl<'ctx, 'blk, B> fmt::Debug for InsertionGuard<'_, 'ctx, 'blk, B>
+where
+    B: OpBuilderLike<'ctx> + ?Sized,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InsertionGuard")
+            .field("point", &self.point)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'ctx, 'blk, B> Drop for InsertionGuard<'_, 'ctx, 'blk, B>
+where
+    B: OpBuilderLike<'ctx> + ?Sized,
+{
+    fn drop(&mut self) {
+        self.builder.restore_insertion_point(self.point);
+    }
+}
+
 /// Trait defining [`OpBuilderLike`] listeners.
 ///
 /// For simple use cases you can use [`SimpleOpBuilderListener`].
@@ -542,6 +597,16 @@ mod tests {
         *Box::new(builder)
     }
 
+    /// Moves an insertion guard through the heap and back.
+    fn move_guard<'builder, 'ctx, 'blk, B>(
+        guard: InsertionGuard<'builder, 'ctx, 'blk, B>,
+    ) -> InsertionGuard<'builder, 'ctx, 'blk, B>
+    where
+        B: OpBuilderLike<'ctx>,
+    {
+        *Box::new(guard)
+    }
+
     #[rstest]
     fn at_block_begin_inserts_before_existing_operations(ctx: Context) {
         let location = Location::unknown(&ctx);
@@ -622,6 +687,25 @@ mod tests {
         builder.restore_insertion_point(saved);
         let third = builder.insert(location, |ctx, loc| index_constant(ctx, loc, 3));
         assert_eq!(second.next_in_block(), Some(first));
+        assert_eq!(first.next_in_block(), Some(third));
+    }
+
+    #[rstest]
+    fn insertion_guard_restores_insertion_point_when_dropped(ctx: Context) {
+        let location = Location::unknown(&ctx);
+        let module = Module::new(location);
+        let body = module.body();
+        let builder = OpBuilder::at_block_begin(&ctx, body);
+
+        let first = builder.insert(location, |ctx, loc| index_constant(ctx, loc, 1));
+        {
+            let _guard = move_guard(builder.insertion_guard());
+            builder.set_insertion_point_at_start(body);
+            let second = builder.insert(location, |ctx, loc| index_constant(ctx, loc, 2));
+            assert_eq!(second.next_in_block(), Some(first));
+        }
+
+        let third = builder.insert(location, |ctx, loc| index_constant(ctx, loc, 3));
         assert_eq!(first.next_in_block(), Some(third));
     }
 

--- a/llzk/src/builder.rs
+++ b/llzk/src/builder.rs
@@ -95,7 +95,7 @@ pub trait OpBuilderLike<'c> {
 
     /// Inserts the operation produced by the closure and returns a reference to it.
     fn insert<'a, F: FnOnce(&'c Context, Location<'c>) -> Operation<'c>>(
-        &'c self,
+        &self,
         loc: Location<'c>,
         f: F,
     ) -> OperationRef<'c, 'a> {

--- a/llzk/src/dialect/array/ops.rs
+++ b/llzk/src/dialect/array/ops.rs
@@ -1,17 +1,16 @@
 //! `array` dialect operations and helper functions.
+use super::ArrayType;
+use crate::{builder::OpBuilderLike, map_operands::MapOperandsBuilder, value_ext::ValueRange};
 use llzk_sys::{
-    llzkArray_CreateArrayOpBuildWithMapOperands, llzkArray_CreateArrayOpBuildWithValues,
+    llzkArray_ArrayLengthOpBuild, llzkArray_CreateArrayOpBuildWithMapOperands,
+    llzkArray_CreateArrayOpBuildWithValues, llzkArray_ExtractArrayOpBuild,
+    llzkArray_InsertArrayOpBuild, llzkArray_ReadArrayOpBuild, llzkArray_WriteArrayOpBuild,
 };
 use melior::ir::{
-    Location, Operation, OperationRef, Type, TypeLike, Value, ValueLike,
-    attribute::DenseI32ArrayAttribute,
-    operation::{OperationBuilder, OperationLike},
+    Location, OperationRef, Type, TypeLike, Value, ValueLike, attribute::DenseI32ArrayAttribute,
+    operation::OperationLike,
 };
 use mlir_sys::MlirOperation;
-
-use crate::{builder::OpBuilderLike, map_operands::MapOperandsBuilder, value_ext::ValueRange};
-
-use super::ArrayType;
 
 /// Possible constructors for creating `array.new` operations.
 #[derive(Debug)]
@@ -108,29 +107,50 @@ pub fn is_array_new<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
     crate::operation::isa(op, "array.new")
 }
 
-fn read_like_op<'c>(
-    name: &str,
+fn read_like_op<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     result: Type<'c>,
     arr_ref: Value<'c, '_>,
     indices: &[Value<'c, '_>],
-) -> Operation<'c> {
-    OperationBuilder::new(name, location)
-        .add_results(&[result])
-        .add_operands(&[arr_ref])
-        .add_operands(indices)
-        .build()
-        .expect("valid operation")
+    build: unsafe extern "C" fn(
+        llzk_sys::MlirOpBuilder,
+        mlir_sys::MlirLocation,
+        mlir_sys::MlirType,
+        mlir_sys::MlirValue,
+        isize,
+        *const mlir_sys::MlirValue,
+    ) -> mlir_sys::MlirOperation,
+) -> OperationRef<'c, 'a> {
+    let raw_indices = indices.iter().map(|v| v.to_raw()).collect::<Vec<_>>();
+    unsafe {
+        OperationRef::from_raw(build(
+            builder.to_raw(),
+            location.to_raw(),
+            result.to_raw(),
+            arr_ref.to_raw(),
+            isize::try_from(raw_indices.len()).expect("indices too large"),
+            raw_indices.as_ptr(),
+        ))
+    }
 }
 
 /// Creates an 'array.read' operation.
-pub fn read<'c>(
+pub fn read<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     result: Type<'c>,
     arr_ref: Value<'c, '_>,
     indices: &[Value<'c, '_>],
-) -> Operation<'c> {
-    read_like_op("array.read", location, result, arr_ref, indices)
+) -> OperationRef<'c, 'a> {
+    read_like_op(
+        builder,
+        location,
+        result,
+        arr_ref,
+        indices,
+        llzkArray_ReadArrayOpBuild,
+    )
 }
 
 /// Return `true` iff the given op is `array.read`.
@@ -140,13 +160,21 @@ pub fn is_array_read<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates an 'array.extract' operation.
-pub fn extract<'c>(
+pub fn extract<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     result: Type<'c>,
     arr_ref: Value<'c, '_>,
     indices: &[Value<'c, '_>],
-) -> Operation<'c> {
-    read_like_op("array.extract", location, result, arr_ref, indices)
+) -> OperationRef<'c, 'a> {
+    read_like_op(
+        builder,
+        location,
+        result,
+        arr_ref,
+        indices,
+        llzkArray_ExtractArrayOpBuild,
+    )
 }
 
 /// Return `true` iff the given op is `array.extract`.
@@ -155,29 +183,50 @@ pub fn is_array_extract<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
     crate::operation::isa(op, "array.extract")
 }
 
-fn write_like_op<'c>(
-    name: &str,
+fn write_like_op<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     arr_ref: Value<'c, '_>,
     indices: &[Value<'c, '_>],
     rvalue: Value<'c, '_>,
-) -> Operation<'c> {
-    OperationBuilder::new(name, location)
-        .add_operands(&[arr_ref])
-        .add_operands(indices)
-        .add_operands(&[rvalue])
-        .build()
-        .expect("valid operation")
+    build: unsafe extern "C" fn(
+        llzk_sys::MlirOpBuilder,
+        mlir_sys::MlirLocation,
+        mlir_sys::MlirValue,
+        isize,
+        *const mlir_sys::MlirValue,
+        mlir_sys::MlirValue,
+    ) -> mlir_sys::MlirOperation,
+) -> OperationRef<'c, 'a> {
+    let raw_indices = indices.iter().map(|v| v.to_raw()).collect::<Vec<_>>();
+    unsafe {
+        OperationRef::from_raw(build(
+            builder.to_raw(),
+            location.to_raw(),
+            arr_ref.to_raw(),
+            isize::try_from(raw_indices.len()).expect("indices too large"),
+            raw_indices.as_ptr(),
+            rvalue.to_raw(),
+        ))
+    }
 }
 
 /// Creates an 'array.write' operation.
-pub fn write<'c>(
+pub fn write<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     arr_ref: Value<'c, '_>,
     indices: &[Value<'c, '_>],
     rvalue: Value<'c, '_>,
-) -> Operation<'c> {
-    write_like_op("array.write", location, arr_ref, indices, rvalue)
+) -> OperationRef<'c, 'a> {
+    write_like_op(
+        builder,
+        location,
+        arr_ref,
+        indices,
+        rvalue,
+        llzkArray_WriteArrayOpBuild,
+    )
 }
 
 /// Return `true` iff the given op is `array.write`.
@@ -187,13 +236,21 @@ pub fn is_array_write<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates an 'array.insert' operation.
-pub fn insert<'c>(
+pub fn insert<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     arr_ref: Value<'c, '_>,
     indices: &[Value<'c, '_>],
     rvalue: Value<'c, '_>,
-) -> Operation<'c> {
-    write_like_op("array.insert", location, arr_ref, indices, rvalue)
+) -> OperationRef<'c, 'a> {
+    write_like_op(
+        builder,
+        location,
+        arr_ref,
+        indices,
+        rvalue,
+        llzkArray_InsertArrayOpBuild,
+    )
 }
 
 /// Return `true` iff the given op is `array.insert`.
@@ -203,17 +260,20 @@ pub fn is_array_insert<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates an 'array.len' operation.
-pub fn len<'c>(
+pub fn len<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     arr_ref: Value<'c, '_>,
     dim: Value<'c, '_>,
-) -> Operation<'c> {
-    let ctx = location.context();
-    OperationBuilder::new("array.len", location)
-        .add_operands(&[arr_ref, dim])
-        .add_results(&[Type::index(unsafe { ctx.to_ref() })])
-        .build()
-        .expect("valid operation")
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkArray_ArrayLengthOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            arr_ref.to_raw(),
+            dim.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `array.len`.

--- a/llzk/src/dialect/array/tests.rs
+++ b/llzk/src/dialect/array/tests.rs
@@ -6,7 +6,7 @@ use melior::{
 use rstest::rstest;
 
 use crate::{
-    builder::{OpBuilder, OpBuilderLike},
+    builder::{OpBuilder, OpBuilderLike as _},
     dialect::array::{ArrayCtor, new},
     test::ctx,
 };

--- a/llzk/src/dialect/array/type.rs
+++ b/llzk/src/dialect/array/type.rs
@@ -6,7 +6,7 @@ use llzk_sys::{
     llzkArray_ArrayTypeGetElementType, llzkArray_ArrayTypeGetWithDims,
     llzkArray_ArrayTypeGetWithShape, llzkTypeIsA_Array_ArrayType,
 };
-use melior::ir::{Attribute, Type, TypeLike};
+use melior::ir::{Attribute, AttributeLike as _, Type, TypeLike};
 use mlir_sys::MlirType;
 
 /// Represents the `!array.type` type.
@@ -37,11 +37,12 @@ impl<'c> ArrayType<'c> {
     ///   - AffineMapAttribute, specifying a dimension size computed from surrounding loop
     ///     induction variables
     pub fn new(element_type: Type<'c>, dims: &[Attribute<'c>]) -> Self {
+        let raw_dims: Vec<_> = dims.iter().map(|dim| dim.to_raw()).collect();
         unsafe {
             Self::from_raw(llzkArray_ArrayTypeGetWithDims(
                 element_type.to_raw(),
-                dims.len() as _,
-                dims.as_ptr() as *const _,
+                raw_dims.len() as _,
+                raw_dims.as_ptr(),
             ))
         }
     }

--- a/llzk/src/dialect/bool/ops.rs
+++ b/llzk/src/dialect/bool/ops.rs
@@ -2,43 +2,50 @@ use crate::{
     builder::OpBuilderLike,
     dialect::bool::{CmpPredicate, CmpPredicateAttribute},
     error::Error,
-    ident,
     macros::isa_fn,
 };
-
-use melior::ir::{
-    Block, Location, Operation, OperationRef, RegionLike, Value, ValueLike,
-    attribute::StringAttribute,
-    operation::{OperationBuilder, OperationLike},
-    r#type::IntegerType,
+use llzk_sys::{
+    llzkBool_AndBoolOpBuild, llzkBool_AssertOpBuild, llzkBool_CmpOpBuild, llzkBool_NotBoolOpBuild,
+    llzkBool_OrBoolOpBuild, llzkBool_XorBoolOpBuild,
 };
+use melior::ir::{
+    AttributeLike, Block, Identifier, Location, OperationRef, RegionLike, Value, ValueLike,
+    operation::OperationLike,
+};
+use mlir_sys::MlirIdentifier;
+use std::ptr::null_mut;
 
-fn build_cmp_op<'c>(
+fn build_cmp_op<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     pred: CmpPredicate,
     location: Location<'c>,
     operands: &[Value<'c, '_>],
-) -> Result<Operation<'c>, Error> {
+) -> Result<OperationRef<'c, 'a>, Error> {
+    let [lhs, rhs] = operands else {
+        return Err(Error::BuildMethodFailed("bool.cmp"));
+    };
     let ctx = location.context();
-    OperationBuilder::new("bool.cmp", location)
-        .add_results(&[IntegerType::new(unsafe { ctx.to_ref() }, 1).into()])
-        .add_operands(operands)
-        .add_attributes(&[(
-            ident!(ctx, "predicate"),
-            CmpPredicateAttribute::new(unsafe { ctx.to_ref() }, pred).into(),
-        )])
-        .build()
-        .map_err(Into::into)
+    Ok(unsafe {
+        OperationRef::from_raw(llzkBool_CmpOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            lhs.to_raw(),
+            rhs.to_raw(),
+            CmpPredicateAttribute::new(ctx.to_ref(), pred).to_raw(),
+        ))
+    })
 }
 
 macro_rules! cmp_binop {
     ($name:ident, $pred:expr) => {
         #[doc = concat!("Creates a `bool.cmp ", stringify!($name) ,"` operation.")]
-        pub fn $name<'c>(
+        pub fn $name<'c, 'a>(
+            builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
             lhs: Value<'c, '_>,
             rhs: Value<'c, '_>,
-        ) -> Result<Operation<'c>, Error> {
-            build_cmp_op($pred, location, &[lhs, rhs])
+        ) -> Result<OperationRef<'c, 'a>, Error> {
+            build_cmp_op(builder, $pred, location, &[lhs, rhs])
         }
     };
 }
@@ -52,31 +59,60 @@ cmp_binop!(ne, CmpPredicate::Ne);
 
 isa_fn!(prefixed bool, cmp);
 
-fn build_op<'c>(
-    name: &str,
+#[inline]
+fn build_binop<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
-    operands: &[Value<'c, '_>],
-) -> Result<Operation<'c>, Error> {
-    let ctx = location.context();
-    OperationBuilder::new(format!("bool.{name}").as_str(), location)
-        .add_results(&[IntegerType::new(unsafe { ctx.to_ref() }, 1).into()])
-        .add_operands(operands)
-        .build()
-        .map_err(Into::into)
+    lhs: Value<'c, '_>,
+    rhs: Value<'c, '_>,
+    build: unsafe extern "C" fn(
+        llzk_sys::MlirOpBuilder,
+        mlir_sys::MlirLocation,
+        mlir_sys::MlirValue,
+        mlir_sys::MlirValue,
+    ) -> mlir_sys::MlirOperation,
+) -> Result<OperationRef<'c, 'a>, Error> {
+    Ok(unsafe {
+        OperationRef::from_raw(build(
+            builder.to_raw(),
+            location.to_raw(),
+            lhs.to_raw(),
+            rhs.to_raw(),
+        ))
+    })
+}
+
+#[inline]
+fn build_unop<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    value: Value<'c, '_>,
+    build: unsafe extern "C" fn(
+        llzk_sys::MlirOpBuilder,
+        mlir_sys::MlirLocation,
+        mlir_sys::MlirValue,
+    ) -> mlir_sys::MlirOperation,
+) -> Result<OperationRef<'c, 'a>, Error> {
+    Ok(unsafe {
+        OperationRef::from_raw(build(builder.to_raw(), location.to_raw(), value.to_raw()))
+    })
 }
 
 macro_rules! binop {
     ($name:ident) => {
-        binop!($name, stringify!($name));
+        paste::paste! {
+            binop!($name, stringify!($name), [<llzkBool_ $name:camel BoolOpBuild>]);
+        }
     };
-    ($name:ident, $opname:expr) => {
+    ($name:ident, $opname:expr, $build:ident) => {
         #[doc = concat!("Creates a `bool.", $opname ,"` operation.")]
-        pub fn $name<'c>(
+        pub fn $name<'c, 'a>(
+            builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
             lhs: Value<'c, '_>,
             rhs: Value<'c, '_>,
-        ) -> Result<Operation<'c>, Error> {
-            build_op($opname, location, &[lhs, rhs])
+        ) -> Result<OperationRef<'c, 'a>, Error> {
+            build_binop(builder, location, lhs, rhs, $build)
         }
 
         isa_fn!(prefixed bool, $name);
@@ -85,48 +121,55 @@ macro_rules! binop {
 
 macro_rules! unop {
     ($name:ident) => {
-        unop!($name, stringify!($name));
+        paste::paste! {
+            unop!($name, stringify!($name), [<llzkBool_ $name:camel BoolOpBuild>]);
+        }
     };
-    ($name:ident, $opname:expr) => {
+    ($name:ident, $opname:expr, $build:ident) => {
         #[doc = concat!("Creates a `bool.", $opname ,"` operation.")]
-        pub fn $name<'c>(
+        pub fn $name<'c, 'a>(
+            builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
             value: Value<'c, '_>,
-        ) -> Result<Operation<'c>, Error> {
-            build_op($opname, location, &[value])
+        ) -> Result<OperationRef<'c, 'a>, Error> {
+            build_unop(builder, location, value, $build)
         }
 
         isa_fn!(prefixed bool, $name);
     };
 }
 
-binop!(and);
-binop!(or);
-binop!(xor);
-unop!(not);
+binop!(and, "and", llzkBool_AndBoolOpBuild);
+binop!(or, "or", llzkBool_OrBoolOpBuild);
+binop!(xor, "xor", llzkBool_XorBoolOpBuild);
+unop!(not, "not", llzkBool_NotBoolOpBuild);
 
 /// Creates a `bool.assert` operation.
-pub fn assert<'c>(
+pub fn assert<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     cond: Value<'c, '_>,
     msg: Option<&str>,
-) -> Result<Operation<'c>, Error> {
+) -> Result<OperationRef<'c, 'a>, Error> {
     let ctx = location.context();
-    let mut builder = OperationBuilder::new("bool.assert", location).add_operands(&[cond]);
-    if let Some(msg) = msg {
-        builder = builder.add_attributes(&[(
-            ident!(ctx, "msg"),
-            StringAttribute::new(unsafe { ctx.to_ref() }, msg).into(),
-        )]);
-    }
-    builder.build().map_err(Into::into)
+    let msg = msg
+        .map(|msg| Identifier::new(unsafe { ctx.to_ref() }, msg).to_raw())
+        .unwrap_or(MlirIdentifier { ptr: null_mut() });
+    Ok(unsafe {
+        OperationRef::from_raw(llzkBool_AssertOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            cond.to_raw(),
+            msg,
+        ))
+    })
 }
 
 isa_fn!(prefixed bool, assert);
 
 /// Helper for creating a quantifier op.
-fn create_quantifier_body<'c, 'a, B>(
-    builder: &B,
+fn create_quantifier_body<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     domain: Value<'c, '_>,
     op_build: unsafe extern "C" fn(
@@ -134,10 +177,7 @@ fn create_quantifier_body<'c, 'a, B>(
         mlir_sys::MlirLocation,
         mlir_sys::MlirValue,
     ) -> mlir_sys::MlirOperation,
-) -> Result<OperationRef<'c, 'a>, Error>
-where
-    B: OpBuilderLike<'c>,
-{
+) -> Result<OperationRef<'c, 'a>, Error> {
     let op = unsafe {
         OperationRef::from_raw(op_build(
             builder.to_raw(),
@@ -155,14 +195,11 @@ where
 /// Creates a `bool.forall` operation.
 ///
 /// Adds an empty block with the correct iteration type based on the domain's type.
-pub fn forall<'c, 'a, B>(
-    builder: &B,
+pub fn forall<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     domain: Value<'c, '_>,
-) -> Result<OperationRef<'c, 'a>, Error>
-where
-    B: OpBuilderLike<'c>,
-{
+) -> Result<OperationRef<'c, 'a>, Error> {
     create_quantifier_body(builder, location, domain, llzk_sys::llzkBool_ForAllOpBuild)
 }
 
@@ -171,22 +208,19 @@ isa_fn!(prefixed bool, forall);
 /// Creates a `bool.exists` operation.
 ///
 /// Adds an empty block with the correct iteration type based on the domain's type.
-pub fn exists<'c, 'a, B>(
-    builder: &B,
+pub fn exists<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     domain: Value<'c, '_>,
-) -> Result<OperationRef<'c, 'a>, Error>
-where
-    B: OpBuilderLike<'c>,
-{
+) -> Result<OperationRef<'c, 'a>, Error> {
     create_quantifier_body(builder, location, domain, llzk_sys::llzkBool_ExistsOpBuild)
 }
 
 isa_fn!(prefixed bool, exists);
 
 /// Creates a `bool.yield` operation.
-pub fn r#yield<'c, 'a, B: OpBuilderLike<'c>>(
-    builder: &B,
+pub fn r#yield<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     value: Value<'c, '_>,
 ) -> OperationRef<'c, 'a> {

--- a/llzk/src/dialect/bool/ops.rs
+++ b/llzk/src/dialect/bool/ops.rs
@@ -9,8 +9,8 @@ use llzk_sys::{
     llzkBool_OrBoolOpBuild, llzkBool_XorBoolOpBuild,
 };
 use melior::ir::{
-    AttributeLike, Block, Identifier, Location, OperationRef, RegionLike, Value, ValueLike,
-    operation::OperationLike,
+    AttributeLike as _, Block, Identifier, Location, OperationRef, RegionLike as _, Value,
+    ValueLike as _, operation::OperationLike as _,
 };
 use mlir_sys::MlirIdentifier;
 use std::ptr::null_mut;
@@ -59,90 +59,16 @@ cmp_binop!(ne, CmpPredicate::Ne);
 
 isa_fn!(prefixed bool, cmp);
 
-#[inline]
-fn build_binop<'c, 'a>(
-    builder: &impl OpBuilderLike<'c>,
-    location: Location<'c>,
-    lhs: Value<'c, '_>,
-    rhs: Value<'c, '_>,
-    build: unsafe extern "C" fn(
-        llzk_sys::MlirOpBuilder,
-        mlir_sys::MlirLocation,
-        mlir_sys::MlirValue,
-        mlir_sys::MlirValue,
-    ) -> mlir_sys::MlirOperation,
-) -> Result<OperationRef<'c, 'a>, Error> {
-    Ok(unsafe {
-        OperationRef::from_raw(build(
-            builder.to_raw(),
-            location.to_raw(),
-            lhs.to_raw(),
-            rhs.to_raw(),
-        ))
-    })
-}
-
-#[inline]
-fn build_unop<'c, 'a>(
-    builder: &impl OpBuilderLike<'c>,
-    location: Location<'c>,
-    value: Value<'c, '_>,
-    build: unsafe extern "C" fn(
-        llzk_sys::MlirOpBuilder,
-        mlir_sys::MlirLocation,
-        mlir_sys::MlirValue,
-    ) -> mlir_sys::MlirOperation,
-) -> Result<OperationRef<'c, 'a>, Error> {
-    Ok(unsafe {
-        OperationRef::from_raw(build(builder.to_raw(), location.to_raw(), value.to_raw()))
-    })
-}
-
-macro_rules! binop {
-    ($name:ident) => {
-        paste::paste! {
-            binop!($name, [<llzkBool_ $name:camel BoolOpBuild>]);
-        }
-    };
-    ($name:ident, $build:ident) => {
-        #[doc = concat!("Creates a `bool.", stringify!($name) ,"` operation.")]
-        pub fn $name<'c, 'a>(
-            builder: &impl OpBuilderLike<'c>,
-            location: Location<'c>,
-            lhs: Value<'c, '_>,
-            rhs: Value<'c, '_>,
-        ) -> Result<OperationRef<'c, 'a>, Error> {
-            build_binop(builder, location, lhs, rhs, $build)
-        }
-
-        isa_fn!(prefixed bool, $name);
+macro_rules! op {
+    ($arity:ident, $($args:tt)*) => {
+        crate::macros::dialect_op!($arity untyped bool, $($args)*);
     };
 }
 
-macro_rules! unop {
-    ($name:ident) => {
-        paste::paste! {
-            unop!($name, [<llzkBool_ $name:camel BoolOpBuild>]);
-        }
-    };
-    ($name:ident, $build:ident) => {
-        #[doc = concat!("Creates a `bool.", stringify!($name) ,"` operation.")]
-        pub fn $name<'c, 'a>(
-            builder: &impl OpBuilderLike<'c>,
-            location: Location<'c>,
-            value: Value<'c, '_>,
-        ) -> Result<OperationRef<'c, 'a>, Error> {
-            build_unop(builder, location, value, $build)
-        }
-
-        isa_fn!(prefixed bool, $name);
-    };
-}
-
-binop!(and, llzkBool_AndBoolOpBuild);
-binop!(or, llzkBool_OrBoolOpBuild);
-binop!(xor, llzkBool_XorBoolOpBuild);
-unop!(not, llzkBool_NotBoolOpBuild);
+op!(binop, and);
+op!(binop, or);
+op!(binop, xor);
+op!(unop, not);
 
 /// Creates a `bool.assert` operation.
 pub fn assert<'c, 'a>(

--- a/llzk/src/dialect/bool/ops.rs
+++ b/llzk/src/dialect/bool/ops.rs
@@ -101,11 +101,11 @@ fn build_unop<'c, 'a>(
 macro_rules! binop {
     ($name:ident) => {
         paste::paste! {
-            binop!($name, stringify!($name), [<llzkBool_ $name:camel BoolOpBuild>]);
+            binop!($name, [<llzkBool_ $name:camel BoolOpBuild>]);
         }
     };
-    ($name:ident, $opname:expr, $build:ident) => {
-        #[doc = concat!("Creates a `bool.", $opname ,"` operation.")]
+    ($name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `bool.", stringify!($name) ,"` operation.")]
         pub fn $name<'c, 'a>(
             builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
@@ -122,11 +122,11 @@ macro_rules! binop {
 macro_rules! unop {
     ($name:ident) => {
         paste::paste! {
-            unop!($name, stringify!($name), [<llzkBool_ $name:camel BoolOpBuild>]);
+            unop!($name, [<llzkBool_ $name:camel BoolOpBuild>]);
         }
     };
-    ($name:ident, $opname:expr, $build:ident) => {
-        #[doc = concat!("Creates a `bool.", $opname ,"` operation.")]
+    ($name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `bool.", stringify!($name) ,"` operation.")]
         pub fn $name<'c, 'a>(
             builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
@@ -139,10 +139,10 @@ macro_rules! unop {
     };
 }
 
-binop!(and, "and", llzkBool_AndBoolOpBuild);
-binop!(or, "or", llzkBool_OrBoolOpBuild);
-binop!(xor, "xor", llzkBool_XorBoolOpBuild);
-unop!(not, "not", llzkBool_NotBoolOpBuild);
+binop!(and, llzkBool_AndBoolOpBuild);
+binop!(or, llzkBool_OrBoolOpBuild);
+binop!(xor, llzkBool_XorBoolOpBuild);
+unop!(not, llzkBool_NotBoolOpBuild);
 
 /// Creates a `bool.assert` operation.
 pub fn assert<'c, 'a>(

--- a/llzk/src/dialect/cast/mod.rs
+++ b/llzk/src/dialect/cast/mod.rs
@@ -1,13 +1,113 @@
 //! `cast` dialect.
 
-use llzk_sys::mlirGetDialectHandle__llzk__cast__;
-use melior::dialect::DialectHandle;
-use melior::ir::{
-    Location, Operation, Type, Value,
-    operation::{OperationBuilder, OperationLike},
-};
-
+use crate::builder::OpBuilderLike;
 use crate::prelude::FeltType;
+use llzk_sys::{
+    LlzkCastOverflowSemantics, llzkAttributeIsA_Cast_OverflowSemanticsAttr,
+    llzkCast_FeltToIndexOpBuild, llzkCast_IntToFeltOpBuildWithType,
+    llzkCast_OverflowSemanticsAttrGet, llzkCast_OverflowSemanticsAttrGetValue,
+    mlirGetDialectHandle__llzk__cast__,
+};
+use melior::{
+    Context,
+    dialect::DialectHandle,
+    ir::{
+        Attribute, AttributeLike, Location, OperationRef, TypeLike, Value, ValueLike,
+        operation::OperationLike,
+    },
+};
+use mlir_sys::MlirAttribute;
+use std::ptr::null_mut;
+
+/// Overflow behavior for cast operations.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum OverflowSemantics {
+    /// Assert that the input fits.
+    Assert = llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_ASSERT,
+    /// Saturate overflowing values.
+    Saturate = llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_SATURATE,
+    /// Wrap overflowing values.
+    Wrap = llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_WRAP,
+    /// Truncate overflowing values.
+    Truncate = llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_TRUNCATE,
+}
+
+impl From<LlzkCastOverflowSemantics> for OverflowSemantics {
+    fn from(value: LlzkCastOverflowSemantics) -> Self {
+        match value {
+            llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_ASSERT => Self::Assert,
+            llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_SATURATE => {
+                Self::Saturate
+            }
+            llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_WRAP => Self::Wrap,
+            llzk_sys::LlzkCastOverflowSemantics_LlzkCastOverflowSemantics_TRUNCATE => {
+                Self::Truncate
+            }
+            _ => panic!("unknown cast overflow semantics value {value}"),
+        }
+    }
+}
+
+/// Attribute representing cast overflow behavior.
+#[derive(Clone, Copy, Debug)]
+pub struct OverflowSemanticsAttribute<'c> {
+    inner: Attribute<'c>,
+}
+
+impl<'c> OverflowSemanticsAttribute<'c> {
+    /// # Safety
+    /// The MLIR attribute must contain a valid pointer of type `OverflowSemanticsAttr`.
+    pub unsafe fn from_raw(attr: MlirAttribute) -> Self {
+        unsafe {
+            Self {
+                inner: Attribute::from_raw(attr),
+            }
+        }
+    }
+
+    /// Creates a new overflow semantics attribute.
+    pub fn new(ctx: &'c Context, semantics: OverflowSemantics) -> Self {
+        unsafe {
+            Self::from_raw(llzkCast_OverflowSemanticsAttrGet(
+                ctx.to_raw(),
+                semantics as LlzkCastOverflowSemantics,
+            ))
+        }
+    }
+
+    /// Returns the represented overflow semantics.
+    pub fn value(&self) -> OverflowSemantics {
+        unsafe { llzkCast_OverflowSemanticsAttrGetValue(self.to_raw()) }.into()
+    }
+}
+
+impl<'c> AttributeLike<'c> for OverflowSemanticsAttribute<'c> {
+    fn to_raw(&self) -> MlirAttribute {
+        self.inner.to_raw()
+    }
+}
+
+impl<'c> TryFrom<Attribute<'c>> for OverflowSemanticsAttribute<'c> {
+    type Error = melior::Error;
+
+    fn try_from(attr: Attribute<'c>) -> Result<Self, Self::Error> {
+        if unsafe { llzkAttributeIsA_Cast_OverflowSemanticsAttr(attr.to_raw()) } {
+            Ok(unsafe { Self::from_raw(attr.to_raw()) })
+        } else {
+            Err(Self::Error::AttributeExpected(
+                "llzk cast overflow semantics attr",
+                attr.to_string(),
+            ))
+        }
+    }
+}
+
+impl<'c> From<OverflowSemanticsAttribute<'c>> for Attribute<'c> {
+    fn from(attr: OverflowSemanticsAttribute<'c>) -> Self {
+        attr.inner
+    }
+}
 
 /// Returns a handle to the `cast` dialect.
 pub fn handle() -> DialectHandle {
@@ -16,18 +116,22 @@ pub fn handle() -> DialectHandle {
 
 /// Creates a 'cast.tofelt' operation with the given target `FeltType` or the
 /// default "unspecified prime" `FeltType` if `None` is provided.
-pub fn tofelt<'c>(
+pub fn tofelt<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     val: Value<'c, '_>,
     out_type: Option<FeltType<'c>>,
-) -> Operation<'c> {
+) -> OperationRef<'c, 'a> {
     let ctx = location.context();
     let out_type = out_type.unwrap_or_else(|| FeltType::new(unsafe { ctx.to_ref() }));
-    OperationBuilder::new("cast.tofelt", location)
-        .add_results(&[out_type.into()])
-        .add_operands(&[val])
-        .build()
-        .expect("valid operation")
+    unsafe {
+        OperationRef::from_raw(llzkCast_IntToFeltOpBuildWithType(
+            builder.to_raw(),
+            location.to_raw(),
+            out_type.to_raw(),
+            val.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `cast.tofelt`.
@@ -37,13 +141,24 @@ pub fn is_cast_tofelt<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates a 'cast.toindex' operation.
-pub fn toindex<'c>(location: Location<'c>, val: Value<'c, '_>) -> Operation<'c> {
+pub fn toindex<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    val: Value<'c, '_>,
+    overflow: Option<OverflowSemantics>,
+) -> OperationRef<'c, 'a> {
     let ctx = location.context();
-    OperationBuilder::new("cast.toindex", location)
-        .add_results(&[Type::index(unsafe { ctx.to_ref() })])
-        .add_operands(&[val])
-        .build()
-        .expect("valid operation")
+    let overflow = overflow
+        .map(|overflow| OverflowSemanticsAttribute::new(unsafe { ctx.to_ref() }, overflow).to_raw())
+        .unwrap_or(MlirAttribute { ptr: null_mut() });
+    unsafe {
+        OperationRef::from_raw(llzkCast_FeltToIndexOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            val.to_raw(),
+            overflow,
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `cast.toindex`.

--- a/llzk/src/dialect/constrain/mod.rs
+++ b/llzk/src/dialect/constrain/mod.rs
@@ -1,12 +1,13 @@
 //! `constrain` dialect.
 
-use llzk_sys::mlirGetDialectHandle__llzk__constrain__;
+use crate::builder::OpBuilderLike;
+use llzk_sys::{
+    llzkConstrain_EmitContainmentOpBuild, llzkConstrain_EmitEqualityOpBuild,
+    mlirGetDialectHandle__llzk__constrain__,
+};
 use melior::{
     dialect::DialectHandle,
-    ir::{
-        Location, Operation, Value,
-        operation::{OperationBuilder, OperationLike},
-    },
+    ir::{Location, OperationRef, Value, ValueLike, operation::OperationLike},
 };
 
 /// Returns a handle to the `constrain` dialect.
@@ -15,11 +16,20 @@ pub fn handle() -> DialectHandle {
 }
 
 /// Creates a `constrain.eq` operation.
-pub fn eq<'c>(location: Location<'c>, lhs: Value<'c, '_>, rhs: Value<'c, '_>) -> Operation<'c> {
-    OperationBuilder::new("constrain.eq", location)
-        .add_operands(&[lhs, rhs])
-        .build()
-        .expect("valid operation")
+pub fn eq<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    lhs: Value<'c, '_>,
+    rhs: Value<'c, '_>,
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkConstrain_EmitEqualityOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            lhs.to_raw(),
+            rhs.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `constrain.eq`.
@@ -29,11 +39,20 @@ pub fn is_constrain_eq<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates a `constrain.in` operation.
-pub fn r#in<'c>(location: Location<'c>, lhs: Value<'c, '_>, rhs: Value<'c, '_>) -> Operation<'c> {
-    OperationBuilder::new("constrain.in", location)
-        .add_operands(&[lhs, rhs])
-        .build()
-        .expect("valid operation")
+pub fn r#in<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    lhs: Value<'c, '_>,
+    rhs: Value<'c, '_>,
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkConstrain_EmitContainmentOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            lhs.to_raw(),
+            rhs.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `constrain.in`.

--- a/llzk/src/dialect/felt/attrs.rs
+++ b/llzk/src/dialect/felt/attrs.rs
@@ -1,3 +1,4 @@
+use super::FeltType;
 use llzk_sys::{
     llzkAttributeIsA_Felt_FeltConstAttr, llzkAttributeIsA_Felt_FieldSpecAttr,
     llzkFelt_FeltConstAttrGet, llzkFelt_FeltConstAttrGetFromParts,
@@ -12,8 +13,6 @@ use melior::{
     ir::{Attribute, AttributeLike, Identifier, TypeLike},
 };
 use mlir_sys::MlirAttribute;
-
-use super::FeltType;
 
 /// A constant finite field element.
 #[derive(Clone, Copy)]
@@ -317,14 +316,13 @@ impl<'c> From<FieldSpecAttribute<'c>> for Attribute<'c> {
 
 #[cfg(test)]
 mod tests {
-    use std::{ops::Deref, ptr::null};
-
     use super::*;
     use crate::prelude::*;
     use log::LevelFilter;
     use quickcheck::{Arbitrary, Gen};
     use quickcheck_macros::quickcheck;
     use simplelog::{Config, TestLogger};
+    use std::{ops::Deref, ptr::null};
 
     #[derive(Clone, Debug)]
     struct FieldArg(Option<String>);
@@ -394,23 +392,20 @@ mod tests {
 
     #[cfg(feature = "bigint")]
     mod bigint {
-        use std::str::FromStr as _;
-
+        use crate::{context::LlzkContext, prelude::FeltConstAttribute};
         use num_bigint::BigUint;
         use rstest::rstest;
-
-        use crate::{context::LlzkContext, prelude::FeltConstAttribute};
+        use std::str::FromStr as _;
 
         #[rstest]
         fn felt_const_attr_new_from_bigint(
             #[values(BigUint::from(0u8), BigUint::from(1u8), BigUint::from_str("21888242871839275222246405745257275088548364400416034343698204186575808495616").unwrap())]
             value: BigUint,
         ) {
-            use std::ptr::null;
-
             use log::LevelFilter;
             use melior::ir::AttributeLike as _;
             use simplelog::{Config, TestLogger};
+            use std::ptr::null;
 
             let _ = TestLogger::init(LevelFilter::Debug, Config::default());
             let ctx = LlzkContext::new();

--- a/llzk/src/dialect/felt/ops.rs
+++ b/llzk/src/dialect/felt/ops.rs
@@ -64,11 +64,8 @@ fn build_unop<'c, 'a>(
 }
 
 macro_rules! binop {
-    ($name:ident) => {
-        binop!($name, stringify!($name));
-    };
-    ($name:ident, $opname:expr, $build:ident) => {
-        #[doc = concat!("Creates a `felt.", $opname ,"` operation.")]
+    ($name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `felt.", stringify!($name) ,"` operation.")]
         pub fn $name<'c, 'a>(
             builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
@@ -79,21 +76,18 @@ macro_rules! binop {
         }
 
         paste::paste! {
-            #[doc = concat!("Return `true` iff the given op is `felt.", $opname ,"`.")]
+            #[doc = concat!("Return `true` iff the given op is `felt.", stringify!($name) ,"`.")]
             #[inline]
             pub fn [<is_felt_ $name>]<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
-                crate::operation::isa(op, concat!("felt.", $opname))
+                crate::operation::isa(op, concat!("felt.", stringify!($name)))
             }
         }
     };
 }
 
 macro_rules! unop {
-    ($name:ident) => {
-        unop!($name, stringify!($name));
-    };
-    ($name:ident, $opname:expr, $build:ident) => {
-        #[doc = concat!("Creates a `felt.", $opname ,"` operation.")]
+    ($name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `felt.", stringify!($name) ,"` operation.")]
         pub fn $name<'c, 'a>(
             builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
@@ -103,32 +97,32 @@ macro_rules! unop {
         }
 
         paste::paste! {
-            #[doc = concat!("Return `true` iff the given op is `felt.", $opname ,"`.")]
+            #[doc = concat!("Return `true` iff the given op is `felt.", stringify!($name) ,"`.")]
             #[inline]
             pub fn [<is_felt_ $name>]<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
-                crate::operation::isa(op, concat!("felt.", $opname))
+                crate::operation::isa(op, concat!("felt.", stringify!($name)))
             }
         }
     };
 }
 
-binop!(add, "add", llzkFelt_AddFeltOpBuild);
-binop!(bit_and, "bit_and", llzkFelt_AndFeltOpBuild);
-binop!(bit_or, "bit_or", llzkFelt_OrFeltOpBuild);
-binop!(bit_xor, "bit_xor", llzkFelt_XorFeltOpBuild);
-binop!(div, "div", llzkFelt_DivFeltOpBuild);
-binop!(mul, "mul", llzkFelt_MulFeltOpBuild);
-binop!(pow, "pow", llzkFelt_PowFeltOpBuild);
-binop!(shl, "shl", llzkFelt_ShlFeltOpBuild);
-binop!(shr, "shr", llzkFelt_ShrFeltOpBuild);
-binop!(sintdiv, "sintdiv", llzkFelt_SignedIntDivFeltOpBuild);
-binop!(smod, "smod", llzkFelt_SignedModFeltOpBuild);
-binop!(sub, "sub", llzkFelt_SubFeltOpBuild);
-binop!(uintdiv, "uintdiv", llzkFelt_UnsignedIntDivFeltOpBuild);
-binop!(umod, "umod", llzkFelt_UnsignedModFeltOpBuild);
-unop!(bit_not, "bit_not", llzkFelt_NotFeltOpBuild);
-unop!(inv, "inv", llzkFelt_InvFeltOpBuild);
-unop!(neg, "neg", llzkFelt_NegFeltOpBuild);
+binop!(add, llzkFelt_AddFeltOpBuild);
+binop!(bit_and, llzkFelt_AndFeltOpBuild);
+binop!(bit_or, llzkFelt_OrFeltOpBuild);
+binop!(bit_xor, llzkFelt_XorFeltOpBuild);
+binop!(div, llzkFelt_DivFeltOpBuild);
+binop!(mul, llzkFelt_MulFeltOpBuild);
+binop!(pow, llzkFelt_PowFeltOpBuild);
+binop!(shl, llzkFelt_ShlFeltOpBuild);
+binop!(shr, llzkFelt_ShrFeltOpBuild);
+binop!(sintdiv, llzkFelt_SignedIntDivFeltOpBuild);
+binop!(smod, llzkFelt_SignedModFeltOpBuild);
+binop!(sub, llzkFelt_SubFeltOpBuild);
+binop!(uintdiv, llzkFelt_UnsignedIntDivFeltOpBuild);
+binop!(umod, llzkFelt_UnsignedModFeltOpBuild);
+unop!(bit_not, llzkFelt_NotFeltOpBuild);
+unop!(inv, llzkFelt_InvFeltOpBuild);
+unop!(neg, llzkFelt_NegFeltOpBuild);
 
 /// Creates a `felt.const` operation.
 pub fn constant<'c, 'a>(

--- a/llzk/src/dialect/felt/ops.rs
+++ b/llzk/src/dialect/felt/ops.rs
@@ -1,36 +1,81 @@
-use crate::{error::Error, ident};
-
 use super::FeltConstAttribute;
+use crate::builder::OpBuilderLike;
+use crate::error::Error;
+use llzk_sys::{
+    llzkFelt_AddFeltOpBuild, llzkFelt_AndFeltOpBuild, llzkFelt_DivFeltOpBuild,
+    llzkFelt_FeltConstantOpBuild, llzkFelt_InvFeltOpBuild, llzkFelt_MulFeltOpBuild,
+    llzkFelt_NegFeltOpBuild, llzkFelt_NotFeltOpBuild, llzkFelt_OrFeltOpBuild,
+    llzkFelt_PowFeltOpBuild, llzkFelt_ShlFeltOpBuild, llzkFelt_ShrFeltOpBuild,
+    llzkFelt_SignedIntDivFeltOpBuild, llzkFelt_SignedModFeltOpBuild, llzkFelt_SubFeltOpBuild,
+    llzkFelt_UnsignedIntDivFeltOpBuild, llzkFelt_UnsignedModFeltOpBuild, llzkFelt_XorFeltOpBuild,
+};
 use melior::ir::{
-    Location, Operation, Type, Value, ValueLike as _,
-    operation::{OperationBuilder, OperationLike},
+    AttributeLike, Location, OperationRef, Type, TypeLike, Value, ValueLike as _,
+    operation::OperationLike,
 };
 
-fn build_op<'c>(
-    name: &str,
+#[inline]
+fn build_binop<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
+    lhs: Value<'c, '_>,
+    rhs: Value<'c, '_>,
     result: Type<'c>,
-    operands: &[Value<'c, '_>],
-) -> Result<Operation<'c>, Error> {
-    OperationBuilder::new(format!("felt.{name}").as_str(), location)
-        .add_results(&[result])
-        .add_operands(operands)
-        .build()
-        .map_err(Into::into)
+    build: unsafe extern "C" fn(
+        llzk_sys::MlirOpBuilder,
+        mlir_sys::MlirLocation,
+        mlir_sys::MlirType,
+        mlir_sys::MlirValue,
+        mlir_sys::MlirValue,
+    ) -> mlir_sys::MlirOperation,
+) -> Result<OperationRef<'c, 'a>, Error> {
+    Ok(unsafe {
+        OperationRef::from_raw(build(
+            builder.to_raw(),
+            location.to_raw(),
+            result.to_raw(),
+            lhs.to_raw(),
+            rhs.to_raw(),
+        ))
+    })
+}
+
+#[inline]
+fn build_unop<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    value: Value<'c, '_>,
+    result: Type<'c>,
+    build: unsafe extern "C" fn(
+        llzk_sys::MlirOpBuilder,
+        mlir_sys::MlirLocation,
+        mlir_sys::MlirType,
+        mlir_sys::MlirValue,
+    ) -> mlir_sys::MlirOperation,
+) -> Result<OperationRef<'c, 'a>, Error> {
+    Ok(unsafe {
+        OperationRef::from_raw(build(
+            builder.to_raw(),
+            location.to_raw(),
+            result.to_raw(),
+            value.to_raw(),
+        ))
+    })
 }
 
 macro_rules! binop {
     ($name:ident) => {
         binop!($name, stringify!($name));
     };
-    ($name:ident, $opname:expr) => {
+    ($name:ident, $opname:expr, $build:ident) => {
         #[doc = concat!("Creates a `felt.", $opname ,"` operation.")]
-        pub fn $name<'c>(
+        pub fn $name<'c, 'a>(
+            builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
             lhs: Value<'c, '_>,
             rhs: Value<'c, '_>,
-        ) -> Result<Operation<'c>, Error> {
-            build_op($opname, location, lhs.r#type(), &[lhs, rhs])
+        ) -> Result<OperationRef<'c, 'a>, Error> {
+            build_binop(builder, location, lhs, rhs, lhs.r#type(), $build)
         }
 
         paste::paste! {
@@ -47,13 +92,14 @@ macro_rules! unop {
     ($name:ident) => {
         unop!($name, stringify!($name));
     };
-    ($name:ident, $opname:expr) => {
+    ($name:ident, $opname:expr, $build:ident) => {
         #[doc = concat!("Creates a `felt.", $opname ,"` operation.")]
-        pub fn $name<'c>(
+        pub fn $name<'c, 'a>(
+            builder: &impl OpBuilderLike<'c>,
             location: Location<'c>,
             value: Value<'c, '_>,
-        ) -> Result<Operation<'c>, Error> {
-            build_op($opname, location, value.r#type(), &[value])
+        ) -> Result<OperationRef<'c, 'a>, Error> {
+            build_unop(builder, location, value, value.r#type(), $build)
         }
 
         paste::paste! {
@@ -66,35 +112,38 @@ macro_rules! unop {
     };
 }
 
-binop!(add);
-binop!(bit_and);
-binop!(bit_or);
-binop!(bit_xor);
-binop!(div);
-binop!(mul);
-binop!(pow);
-binop!(shl);
-binop!(shr);
-binop!(sintdiv);
-binop!(smod);
-binop!(sub);
-binop!(uintdiv);
-binop!(umod);
-unop!(bit_not);
-unop!(inv);
-unop!(neg);
+binop!(add, "add", llzkFelt_AddFeltOpBuild);
+binop!(bit_and, "bit_and", llzkFelt_AndFeltOpBuild);
+binop!(bit_or, "bit_or", llzkFelt_OrFeltOpBuild);
+binop!(bit_xor, "bit_xor", llzkFelt_XorFeltOpBuild);
+binop!(div, "div", llzkFelt_DivFeltOpBuild);
+binop!(mul, "mul", llzkFelt_MulFeltOpBuild);
+binop!(pow, "pow", llzkFelt_PowFeltOpBuild);
+binop!(shl, "shl", llzkFelt_ShlFeltOpBuild);
+binop!(shr, "shr", llzkFelt_ShrFeltOpBuild);
+binop!(sintdiv, "sintdiv", llzkFelt_SignedIntDivFeltOpBuild);
+binop!(smod, "smod", llzkFelt_SignedModFeltOpBuild);
+binop!(sub, "sub", llzkFelt_SubFeltOpBuild);
+binop!(uintdiv, "uintdiv", llzkFelt_UnsignedIntDivFeltOpBuild);
+binop!(umod, "umod", llzkFelt_UnsignedModFeltOpBuild);
+unop!(bit_not, "bit_not", llzkFelt_NotFeltOpBuild);
+unop!(inv, "inv", llzkFelt_InvFeltOpBuild);
+unop!(neg, "neg", llzkFelt_NegFeltOpBuild);
 
 /// Creates a `felt.const` operation.
-pub fn constant<'c>(
+pub fn constant<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     value: FeltConstAttribute<'c>,
-) -> Result<Operation<'c>, Error> {
-    let ctx = location.context();
-    OperationBuilder::new("felt.const", location)
-        .add_results(&[value.r#type().into()])
-        .add_attributes(&[(ident!(ctx, "value"), value.into())])
-        .build()
-        .map_err(Into::into)
+) -> Result<OperationRef<'c, 'a>, Error> {
+    Ok(unsafe {
+        OperationRef::from_raw(llzkFelt_FeltConstantOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            value.r#type().to_raw(),
+            value.to_raw(),
+        ))
+    })
 }
 
 /// Return `true` iff the given op is `felt.const`.
@@ -114,7 +163,10 @@ mod tests {
         // ensure value fits in i64, which is what's internally used by FeltConstAttribute
         let value = value % (i64::MAX as u64 + 1);
         let ctx = LlzkContext::new();
+        let module = Module::new(Location::unknown(&ctx));
+        let builder = crate::builder::OpBuilder::at_block_begin(&ctx, module.body());
         let op = constant(
+            &builder,
             Location::unknown(&ctx),
             FeltConstAttribute::new(&ctx, value, None),
         )
@@ -127,7 +179,10 @@ mod tests {
         // ensure value fits in i64, which is what's internally used by FeltConstAttribute
         let value = value % (i64::MAX as u64 + 1);
         let ctx = LlzkContext::new();
+        let module = Module::new(Location::unknown(&ctx));
+        let builder = crate::builder::OpBuilder::at_block_begin(&ctx, module.body());
         let op = constant(
+            &builder,
             Location::unknown(&ctx),
             FeltConstAttribute::new(&ctx, value, None),
         )

--- a/llzk/src/dialect/felt/ops.rs
+++ b/llzk/src/dialect/felt/ops.rs
@@ -1,6 +1,5 @@
 use super::FeltConstAttribute;
-use crate::builder::OpBuilderLike;
-use crate::error::Error;
+use crate::{builder::OpBuilderLike, error::Error, macros::isa_fn};
 use llzk_sys::{
     llzkFelt_AddFeltOpBuild, llzkFelt_AndFeltOpBuild, llzkFelt_DivFeltOpBuild,
     llzkFelt_FeltConstantOpBuild, llzkFelt_InvFeltOpBuild, llzkFelt_MulFeltOpBuild,
@@ -10,119 +9,32 @@ use llzk_sys::{
     llzkFelt_UnsignedIntDivFeltOpBuild, llzkFelt_UnsignedModFeltOpBuild, llzkFelt_XorFeltOpBuild,
 };
 use melior::ir::{
-    AttributeLike, Location, OperationRef, Type, TypeLike, Value, ValueLike as _,
-    operation::OperationLike,
+    AttributeLike as _, Location, OperationRef, TypeLike as _, operation::OperationLike,
 };
 
-#[inline]
-fn build_binop<'c, 'a>(
-    builder: &impl OpBuilderLike<'c>,
-    location: Location<'c>,
-    lhs: Value<'c, '_>,
-    rhs: Value<'c, '_>,
-    result: Type<'c>,
-    build: unsafe extern "C" fn(
-        llzk_sys::MlirOpBuilder,
-        mlir_sys::MlirLocation,
-        mlir_sys::MlirType,
-        mlir_sys::MlirValue,
-        mlir_sys::MlirValue,
-    ) -> mlir_sys::MlirOperation,
-) -> Result<OperationRef<'c, 'a>, Error> {
-    Ok(unsafe {
-        OperationRef::from_raw(build(
-            builder.to_raw(),
-            location.to_raw(),
-            result.to_raw(),
-            lhs.to_raw(),
-            rhs.to_raw(),
-        ))
-    })
-}
-
-#[inline]
-fn build_unop<'c, 'a>(
-    builder: &impl OpBuilderLike<'c>,
-    location: Location<'c>,
-    value: Value<'c, '_>,
-    result: Type<'c>,
-    build: unsafe extern "C" fn(
-        llzk_sys::MlirOpBuilder,
-        mlir_sys::MlirLocation,
-        mlir_sys::MlirType,
-        mlir_sys::MlirValue,
-    ) -> mlir_sys::MlirOperation,
-) -> Result<OperationRef<'c, 'a>, Error> {
-    Ok(unsafe {
-        OperationRef::from_raw(build(
-            builder.to_raw(),
-            location.to_raw(),
-            result.to_raw(),
-            value.to_raw(),
-        ))
-    })
-}
-
-macro_rules! binop {
-    ($name:ident, $build:ident) => {
-        #[doc = concat!("Creates a `felt.", stringify!($name) ,"` operation.")]
-        pub fn $name<'c, 'a>(
-            builder: &impl OpBuilderLike<'c>,
-            location: Location<'c>,
-            lhs: Value<'c, '_>,
-            rhs: Value<'c, '_>,
-        ) -> Result<OperationRef<'c, 'a>, Error> {
-            build_binop(builder, location, lhs, rhs, lhs.r#type(), $build)
-        }
-
-        paste::paste! {
-            #[doc = concat!("Return `true` iff the given op is `felt.", stringify!($name) ,"`.")]
-            #[inline]
-            pub fn [<is_felt_ $name>]<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
-                crate::operation::isa(op, concat!("felt.", stringify!($name)))
-            }
-        }
+macro_rules! op {
+    ($arity:ident, $($args:tt)*) => {
+        crate::macros::dialect_op!($arity typed felt, $($args)*);
     };
 }
 
-macro_rules! unop {
-    ($name:ident, $build:ident) => {
-        #[doc = concat!("Creates a `felt.", stringify!($name) ,"` operation.")]
-        pub fn $name<'c, 'a>(
-            builder: &impl OpBuilderLike<'c>,
-            location: Location<'c>,
-            value: Value<'c, '_>,
-        ) -> Result<OperationRef<'c, 'a>, Error> {
-            build_unop(builder, location, value, value.r#type(), $build)
-        }
-
-        paste::paste! {
-            #[doc = concat!("Return `true` iff the given op is `felt.", stringify!($name) ,"`.")]
-            #[inline]
-            pub fn [<is_felt_ $name>]<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
-                crate::operation::isa(op, concat!("felt.", stringify!($name)))
-            }
-        }
-    };
-}
-
-binop!(add, llzkFelt_AddFeltOpBuild);
-binop!(bit_and, llzkFelt_AndFeltOpBuild);
-binop!(bit_or, llzkFelt_OrFeltOpBuild);
-binop!(bit_xor, llzkFelt_XorFeltOpBuild);
-binop!(div, llzkFelt_DivFeltOpBuild);
-binop!(mul, llzkFelt_MulFeltOpBuild);
-binop!(pow, llzkFelt_PowFeltOpBuild);
-binop!(shl, llzkFelt_ShlFeltOpBuild);
-binop!(shr, llzkFelt_ShrFeltOpBuild);
-binop!(sintdiv, llzkFelt_SignedIntDivFeltOpBuild);
-binop!(smod, llzkFelt_SignedModFeltOpBuild);
-binop!(sub, llzkFelt_SubFeltOpBuild);
-binop!(uintdiv, llzkFelt_UnsignedIntDivFeltOpBuild);
-binop!(umod, llzkFelt_UnsignedModFeltOpBuild);
-unop!(bit_not, llzkFelt_NotFeltOpBuild);
-unop!(inv, llzkFelt_InvFeltOpBuild);
-unop!(neg, llzkFelt_NegFeltOpBuild);
+op!(binop, add);
+op!(binop, sub);
+op!(binop, div);
+op!(binop, mul);
+op!(binop, pow);
+op!(binop, shl);
+op!(binop, shr);
+op!(binop, sintdiv, llzkFelt_SignedIntDivFeltOpBuild);
+op!(binop, smod, llzkFelt_SignedModFeltOpBuild);
+op!(binop, uintdiv, llzkFelt_UnsignedIntDivFeltOpBuild);
+op!(binop, umod, llzkFelt_UnsignedModFeltOpBuild);
+op!(binop, bit_and, llzkFelt_AndFeltOpBuild);
+op!(binop, bit_or, llzkFelt_OrFeltOpBuild);
+op!(binop, bit_xor, llzkFelt_XorFeltOpBuild);
+op!(unop, inv);
+op!(unop, neg);
+op!(unop, bit_not, llzkFelt_NotFeltOpBuild);
 
 /// Creates a `felt.const` operation.
 pub fn constant<'c, 'a>(

--- a/llzk/src/dialect/felt/type.rs
+++ b/llzk/src/dialect/felt/type.rs
@@ -76,8 +76,9 @@ pub fn is_felt_type(t: Type) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::builder::OpBuilder;
     use crate::context::LlzkContext;
-    use melior::ir::{Location, operation::OperationLike};
+    use melior::ir::{Location, Module, operation::OperationLike};
     use rstest::rstest;
 
     #[rstest]
@@ -88,7 +89,9 @@ mod tests {
         // Test by printing.
         assert_eq!(t.to_string(), format!("!felt.type<\"{field}\">"));
         // And by using some op that we validate.
-        let op = crate::dialect::llzk::nondet(Location::unknown(&ctx), t.into());
+        let module = Module::new(Location::unknown(&ctx));
+        let builder = OpBuilder::at_block_begin(&ctx, module.body());
+        let op = crate::dialect::llzk::nondet(&builder, Location::unknown(&ctx), t.into());
         assert!(op.verify());
     }
 }

--- a/llzk/src/dialect/function/ops.rs
+++ b/llzk/src/dialect/function/ops.rs
@@ -683,14 +683,15 @@ where
     };
     let op: FuncDefOpRef<'c, 'a> = op.try_into()?;
 
-    let block_args = (0..r#type.input_count())
-        .map(|idx| r#type.input(idx).map(|ty| (ty, location)))
-        .collect::<Result<Vec<_>, _>>()?;
-
     let region = op.body()?;
     let block = match region.first_block() {
         Some(block) => block,
-        None => region.append_block(Block::new(&block_args)),
+        None => {
+            let block_args = (0..r#type.input_count())
+                .map(|idx| r#type.input(idx).map(|ty| (ty, location)))
+                .collect::<Result<Vec<_>, _>>()?;
+            region.append_block(Block::new(&block_args))
+        }
     };
 
     let _guard = builder.insertion_guard();

--- a/llzk/src/dialect/function/ops.rs
+++ b/llzk/src/dialect/function/ops.rs
@@ -22,7 +22,7 @@ use llzk_sys::{
     llzkFunction_CallOpGetSelfValueFromCompute, llzkFunction_CallOpGetSelfValueFromConstrain,
     llzkFunction_CallOpGetTemplateParams, llzkFunction_CallOpSetArgOperands,
     llzkFunction_CallOpSetCallee, llzkFunction_CallOpSetMapOperands,
-    llzkFunction_CallOpSetTemplateParams, llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs,
+    llzkFunction_CallOpSetTemplateParams, llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs,
     llzkFunction_FuncDefOpGetArgAttrs, llzkFunction_FuncDefOpGetArgNameAttr,
     llzkFunction_FuncDefOpGetBody, llzkFunction_FuncDefOpGetFullyQualifiedName,
     llzkFunction_FuncDefOpGetFunctionType, llzkFunction_FuncDefOpGetResAttrs,
@@ -650,7 +650,7 @@ pub fn def<'c>(
     let attrs: Vec<_> = attrs.iter().map(tuple_to_raw_named_attr).collect();
     let arg_attrs = prepare_arg_attrs(arg_attrs, r#type.input_count(), unsafe { ctx.to_ref() });
     unsafe {
-        Operation::from_raw(llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
+        Operation::from_raw(llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
             location.to_raw(),
             name.to_raw(),
             r#type.to_raw(),

--- a/llzk/src/dialect/function/ops.rs
+++ b/llzk/src/dialect/function/ops.rs
@@ -47,8 +47,8 @@ use llzk_sys::{
 use melior::{
     Context, StringRef,
     ir::{
-        Attribute, AttributeLike, BlockLike as _, Location, Operation, OperationRef,
-        RegionLike as _, RegionRef, Type, TypeLike, Value, ValueLike,
+        Attribute, AttributeLike, BlockLike as _, Location, OperationRef, RegionLike as _,
+        RegionRef, Type, TypeLike, Value, ValueLike,
         attribute::{StringAttribute, TypeAttribute},
         block::BlockArgument,
         operation::{OperationLike, OperationMutLike},
@@ -650,8 +650,9 @@ pub fn def<'c, 'a>(
     let name = StringRef::new(name);
     let attrs: Vec<_> = attrs.iter().map(tuple_to_raw_named_attr).collect();
     let arg_attrs = prepare_arg_attrs(arg_attrs, r#type.input_count(), unsafe { ctx.to_ref() });
-    let op = unsafe {
-        Operation::from_raw(llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
+    unsafe {
+        OperationRef::from_raw(llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
+            builder.to_raw(),
             location.to_raw(),
             name.to_raw(),
             r#type.to_raw(),
@@ -660,9 +661,8 @@ pub fn def<'c, 'a>(
             isize::try_from(arg_attrs.len()).expect("arg_attrs too large"),
             arg_attrs.as_ptr(),
         ))
-    };
-    // TODO: insertion is temporary until the CAPI is updated to do the insertion
-    builder.insert(location, |_, _| op).try_into()
+    }
+    .try_into()
 }
 
 /// Creates a `function.def` operation and optionally sets both argument and result attributes.

--- a/llzk/src/dialect/function/ops.rs
+++ b/llzk/src/dialect/function/ops.rs
@@ -650,6 +650,16 @@ pub fn def<'c, 'a>(
     let name = StringRef::new(name);
     let attrs: Vec<_> = attrs.iter().map(tuple_to_raw_named_attr).collect();
     let arg_attrs = prepare_arg_attrs(arg_attrs, r#type.input_count(), unsafe { ctx.to_ref() });
+    let attrs_ptr = if attrs.is_empty() {
+        std::ptr::null()
+    } else {
+        attrs.as_ptr()
+    };
+    let arg_attrs_ptr = if arg_attrs.is_empty() {
+        std::ptr::null()
+    } else {
+        arg_attrs.as_ptr()
+    };
     unsafe {
         OperationRef::from_raw(llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
             builder.to_raw(),
@@ -657,9 +667,9 @@ pub fn def<'c, 'a>(
             name.to_raw(),
             r#type.to_raw(),
             isize::try_from(attrs.len()).expect("attrs too large"),
-            attrs.as_ptr(),
+            attrs_ptr,
             isize::try_from(arg_attrs.len()).expect("arg_attrs too large"),
-            arg_attrs.as_ptr(),
+            arg_attrs_ptr,
         ))
     }
     .try_into()

--- a/llzk/src/dialect/function/ops.rs
+++ b/llzk/src/dialect/function/ops.rs
@@ -8,6 +8,7 @@ use crate::{
     error::Error,
     macros::llzk_op_type,
     map_operands::MapOperandsBuilder,
+    operation::detach_and_erase_op,
     symbol_ref::{SymbolRefAttrLike, SymbolRefAttribute},
 };
 use llzk_sys::{
@@ -47,7 +48,7 @@ use llzk_sys::{
 use melior::{
     Context, StringRef,
     ir::{
-        Attribute, AttributeLike, BlockLike as _, Location, OperationRef, RegionLike as _,
+        Attribute, AttributeLike, Block, BlockLike as _, Location, OperationRef, RegionLike as _,
         RegionRef, Type, TypeLike, Value, ValueLike,
         attribute::{StringAttribute, TypeAttribute},
         block::BlockArgument,
@@ -635,17 +636,25 @@ fn prepare_arg_attrs<'c>(
         .collect()
 }
 
-/// Creates a 'function.def' operation. If the arg_attrs parameter is None creates as many empty
-/// argument attributes as input arguments there are to satisfy the requirement of one
-/// DictionaryAttr per argument.
-pub fn def<'c, 'a>(
-    builder: &impl OpBuilderLike<'c>,
+/// Creates a 'function.def' operation and fills its body with operations produced
+/// by the callback. If the arg_attrs parameter is [`None`] creates as many empty
+/// argument attributes as input arguments there are to satisfy the requirement of
+/// one `DictionaryAttr` per argument.
+///
+/// Use [`crate::dialect::empty_region`] as the `fill` callback to leave the body
+/// empty so contents can be added later.
+pub fn def<'c, 'a, B>(
+    builder: &B,
     location: Location<'c>,
     name: &str,
     r#type: FunctionType<'c>,
     attrs: &[NamedAttribute<'c>],
     arg_attrs: Option<&[Vec<NamedAttribute<'c>>]>,
-) -> Result<FuncDefOpRef<'c, 'a>, Error> {
+    fill: impl FnOnce(&B) -> Result<(), Error>,
+) -> Result<FuncDefOpRef<'c, 'a>, Error>
+where
+    B: OpBuilderLike<'c>,
+{
     let ctx = location.context();
     let name = StringRef::new(name);
     let attrs: Vec<_> = attrs.iter().map(tuple_to_raw_named_attr).collect();
@@ -660,7 +669,7 @@ pub fn def<'c, 'a>(
     } else {
         arg_attrs.as_ptr()
     };
-    unsafe {
+    let op = unsafe {
         OperationRef::from_raw(llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
             builder.to_raw(),
             location.to_raw(),
@@ -671,8 +680,28 @@ pub fn def<'c, 'a>(
             isize::try_from(arg_attrs.len()).expect("arg_attrs too large"),
             arg_attrs_ptr,
         ))
+    };
+    let op: FuncDefOpRef<'c, 'a> = op.try_into()?;
+
+    let block_args = (0..r#type.input_count())
+        .map(|idx| r#type.input(idx).map(|ty| (ty, location)))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let region = op.body()?;
+    let block = match region.first_block() {
+        Some(block) => block,
+        None => region.append_block(Block::new(&block_args)),
+    };
+
+    let _guard = builder.insertion_guard();
+    builder.set_insertion_point_at_start(block);
+    match fill(builder) {
+        Ok(()) => Ok(op),
+        Err(err) => {
+            detach_and_erase_op(op);
+            Err(err)
+        }
     }
-    .try_into()
 }
 
 /// Creates a `function.def` operation and optionally sets both argument and result attributes.
@@ -687,7 +716,15 @@ pub fn def_with_signature_attrs<'c, 'a>(
 ) -> Result<FuncDefOpRef<'c, 'a>, Error> {
     let context_ref = location.context();
     let context = unsafe { context_ref.to_ref() };
-    let op = def(builder, location, name, r#type, attrs, arg_attrs)?;
+    let op = def(
+        builder,
+        location,
+        name,
+        r#type,
+        attrs,
+        arg_attrs,
+        crate::dialect::empty_region,
+    )?;
     if let Some(arg_attrs) = arg_attrs {
         let attr = ArrayAttribute::new(
             context,

--- a/llzk/src/dialect/function/ops.rs
+++ b/llzk/src/dialect/function/ops.rs
@@ -10,7 +10,6 @@ use crate::{
     map_operands::MapOperandsBuilder,
     symbol_ref::{SymbolRefAttrLike, SymbolRefAttribute},
 };
-
 use llzk_sys::{
     llzkFunction_CallOpBuild, llzkFunction_CallOpBuildWithMapOperands,
     llzkFunction_CallOpBuildWithTemplateParams, llzkFunction_CallOpCalleeIsCompute,
@@ -42,16 +41,17 @@ use llzk_sys::{
     llzkFunction_FuncDefOpSetArgNameAttr, llzkFunction_FuncDefOpSetFunctionType,
     llzkFunction_FuncDefOpSetResAttrs, llzkFunction_FuncDefOpSetResName,
     llzkFunction_FuncDefOpSetResNameAttr, llzkFunction_FuncDefOpSetSymName,
-    llzkOperationIsA_Function_CallOp, llzkOperationIsA_Function_FuncDefOp,
+    llzkFunction_ReturnOpBuild, llzkOperationIsA_Function_CallOp,
+    llzkOperationIsA_Function_FuncDefOp,
 };
 use melior::{
     Context, StringRef,
     ir::{
         Attribute, AttributeLike, BlockLike as _, Location, Operation, OperationRef,
-        RegionLike as _, RegionRef, Type, TypeLike, Value,
+        RegionLike as _, RegionRef, Type, TypeLike, Value, ValueLike,
         attribute::{StringAttribute, TypeAttribute},
         block::BlockArgument,
-        operation::{OperationBuilder, OperationLike, OperationMutLike},
+        operation::{OperationLike, OperationMutLike},
         r#type::FunctionType,
     },
 };
@@ -638,18 +638,19 @@ fn prepare_arg_attrs<'c>(
 /// Creates a 'function.def' operation. If the arg_attrs parameter is None creates as many empty
 /// argument attributes as input arguments there are to satisfy the requirement of one
 /// DictionaryAttr per argument.
-pub fn def<'c>(
+pub fn def<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     name: &str,
     r#type: FunctionType<'c>,
     attrs: &[NamedAttribute<'c>],
     arg_attrs: Option<&[Vec<NamedAttribute<'c>>]>,
-) -> Result<FuncDefOp<'c>, Error> {
+) -> Result<FuncDefOpRef<'c, 'a>, Error> {
     let ctx = location.context();
     let name = StringRef::new(name);
     let attrs: Vec<_> = attrs.iter().map(tuple_to_raw_named_attr).collect();
     let arg_attrs = prepare_arg_attrs(arg_attrs, r#type.input_count(), unsafe { ctx.to_ref() });
-    unsafe {
+    let op = unsafe {
         Operation::from_raw(llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
             location.to_raw(),
             name.to_raw(),
@@ -659,22 +660,24 @@ pub fn def<'c>(
             isize::try_from(arg_attrs.len()).expect("arg_attrs too large"),
             arg_attrs.as_ptr(),
         ))
-    }
-    .try_into()
+    };
+    // TODO: insertion is temporary until the CAPI is updated to do the insertion
+    builder.insert(location, |_, _| op).try_into()
 }
 
 /// Creates a `function.def` operation and optionally sets both argument and result attributes.
-pub fn def_with_signature_attrs<'c>(
+pub fn def_with_signature_attrs<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     name: &str,
     r#type: FunctionType<'c>,
     attrs: &[NamedAttribute<'c>],
     arg_attrs: Option<&[Vec<NamedAttribute<'c>>]>,
     res_attrs: Option<&[Vec<NamedAttribute<'c>>]>,
-) -> Result<FuncDefOp<'c>, Error> {
+) -> Result<FuncDefOpRef<'c, 'a>, Error> {
     let context_ref = location.context();
     let context = unsafe { context_ref.to_ref() };
-    let op = def(location, name, r#type, attrs, arg_attrs)?;
+    let op = def(builder, location, name, r#type, attrs, arg_attrs)?;
     if let Some(arg_attrs) = arg_attrs {
         let attr = ArrayAttribute::new(
             context,
@@ -788,11 +791,20 @@ pub fn is_func_call<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 /// This operation is the terminator op for `function.def` and must be the last operation of the
 /// last block in it. The values array must match the number of outputs, and their types, of the
 /// parent function.
-pub fn r#return<'c>(location: Location<'c>, values: &[Value<'c, '_>]) -> Operation<'c> {
-    OperationBuilder::new("function.return", location)
-        .add_operands(values)
-        .build()
-        .unwrap()
+pub fn r#return<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    values: &[Value<'c, '_>],
+) -> OperationRef<'c, 'a> {
+    let raw_values = values.iter().map(|v| v.to_raw()).collect::<Vec<_>>();
+    unsafe {
+        OperationRef::from_raw(llzkFunction_ReturnOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            isize::try_from(raw_values.len()).expect("values too large"),
+            raw_values.as_ptr(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `function.return`.

--- a/llzk/src/dialect/global/mod.rs
+++ b/llzk/src/dialect/global/mod.rs
@@ -1,16 +1,19 @@
 //! `global` dialect.
 
-use llzk_sys::mlirGetDialectHandle__llzk__global__;
+use crate::{builder::OpBuilderLike, symbol_ref::SymbolRefAttribute};
+use llzk_sys::{
+    llzkGlobal_GlobalDefOpBuild, llzkGlobal_GlobalReadOpBuild, llzkGlobal_GlobalWriteOpBuild,
+    mlirGetDialectHandle__llzk__global__,
+};
 use melior::{
     dialect::DialectHandle,
     ir::{
-        Attribute, Location, Operation, Type, Value,
-        attribute::{StringAttribute, TypeAttribute},
-        operation::{OperationBuilder, OperationLike},
+        Attribute, AttributeLike, Identifier, Location, OperationRef, Type, TypeLike, Value,
+        ValueLike, attribute::TypeAttribute, operation::OperationLike,
     },
 };
-
-use crate::{ident, symbol_ref::SymbolRefAttribute};
+use mlir_sys::MlirAttribute;
+use std::ptr::null_mut;
 
 /// Returns a handle to the `global` dialect.
 pub fn handle() -> DialectHandle {
@@ -18,34 +21,31 @@ pub fn handle() -> DialectHandle {
 }
 
 /// Constructs a 'global.def' operation.
-pub fn def<'c>(
+pub fn def<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     name: &str,
     r#type: Type<'c>,
     constant: bool,
     initial_value: Option<Attribute<'c>>,
-) -> Operation<'c> {
+) -> OperationRef<'c, 'a> {
     let ctx = location.context();
-    let mut attrs = vec![
-        (
-            ident!(ctx, "sym_name"),
-            StringAttribute::new(unsafe { ctx.to_ref() }, name).into(),
-        ),
-        (ident!(ctx, "type"), TypeAttribute::new(r#type).into()),
-    ];
-    if constant {
-        attrs.push((
-            ident!(ctx, "constant"),
-            Attribute::unit(unsafe { ctx.to_ref() }),
-        ));
+    let null_attr = MlirAttribute { ptr: null_mut() };
+    let constant = if constant {
+        Attribute::unit(unsafe { ctx.to_ref() }).to_raw()
+    } else {
+        null_attr
+    };
+    unsafe {
+        OperationRef::from_raw(llzkGlobal_GlobalDefOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            Identifier::new(ctx.to_ref(), name).to_raw(),
+            constant,
+            TypeAttribute::new(r#type).to_raw(),
+            initial_value.map_or(null_attr, |attr| attr.to_raw()),
+        ))
     }
-    if let Some(initial_value) = initial_value {
-        attrs.push((ident!(ctx, "initial_value"), initial_value));
-    }
-    OperationBuilder::new("global.def", location)
-        .add_attributes(&attrs)
-        .build()
-        .expect("valid operation")
 }
 
 /// Return `true` iff the given op is `global.def`.
@@ -55,17 +55,20 @@ pub fn is_global_def<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Constructs a 'global.read' operation.
-pub fn read<'c>(
+pub fn read<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     name: SymbolRefAttribute<'c>,
     result: Type<'c>,
-) -> Operation<'c> {
-    let ctx = location.context();
-    OperationBuilder::new("global.read", location)
-        .add_attributes(&[(ident!(ctx, "name_ref"), name.into())])
-        .add_results(&[result])
-        .build()
-        .expect("valid operation")
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkGlobal_GlobalReadOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            result.to_raw(),
+            name.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `global.read`.
@@ -75,17 +78,20 @@ pub fn is_global_read<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Constructs a 'global.write' operation.
-pub fn write<'c>(
+pub fn write<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     name: SymbolRefAttribute<'c>,
     value: Value<'c, '_>,
-) -> Operation<'c> {
-    let ctx = location.context();
-    OperationBuilder::new("global.write", location)
-        .add_attributes(&[(ident!(ctx, "name_ref"), name.into())])
-        .add_operands(&[value])
-        .build()
-        .expect("valid operation")
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkGlobal_GlobalWriteOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            value.to_raw(),
+            name.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `global.write`.

--- a/llzk/src/dialect/llzk/ops.rs
+++ b/llzk/src/dialect/llzk/ops.rs
@@ -1,14 +1,20 @@
-use melior::ir::{
-    Location, Operation, Type,
-    operation::{OperationBuilder, OperationLike},
-};
+use crate::builder::OpBuilderLike;
+use llzk_sys::llzkLlzk_NonDetOpBuild;
+use melior::ir::{Location, OperationRef, Type, TypeLike, operation::OperationLike};
 
 /// Creates a new `llzk.nondet` operation.
-pub fn nondet<'c>(location: Location<'c>, result_type: Type<'c>) -> Operation<'c> {
-    OperationBuilder::new("llzk.nondet", location)
-        .add_results(&[result_type])
-        .build()
-        .unwrap()
+pub fn nondet<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    result_type: Type<'c>,
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkLlzk_NonDetOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            result_type.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `llzk.nondet`.

--- a/llzk/src/dialect/mod.rs
+++ b/llzk/src/dialect/mod.rs
@@ -1,5 +1,7 @@
 //! APIs for the different dialects available in LLZK.
 
+use crate::{builder::OpBuilderLike, error::Error};
+
 pub mod array;
 pub mod bool;
 pub mod cast;
@@ -13,6 +15,14 @@ pub mod poly;
 pub mod ram;
 pub mod r#struct;
 pub mod verif;
+
+/// A no-op callback for region-building functions.
+///
+/// Use this as the `fill` callback when creating an operation with an empty
+/// region so body contents can be added later.
+pub fn empty_region<'c>(_: &impl OpBuilderLike<'c>) -> Result<(), Error> {
+    Ok(())
+}
 
 /// Functions for working with `builtin.module` in LLZK.
 pub mod module {

--- a/llzk/src/dialect/pod/ops.rs
+++ b/llzk/src/dialect/pod/ops.rs
@@ -1,16 +1,14 @@
 //! `pod` dialect operations and helper functions.
 
 use super::r#type::PodType;
-use crate::{builder::OpBuilderLike, ident, map_operands::MapOperandsBuilder};
+use crate::{builder::OpBuilderLike, map_operands::MapOperandsBuilder};
 use llzk_sys::{
     LlzkRecordValue, llzkPod_NewPodOpBuild, llzkPod_NewPodOpBuildInferredFromInitialValues,
-    llzkPod_NewPodOpBuildWithMapOperands,
+    llzkPod_NewPodOpBuildWithMapOperands, llzkPod_ReadPodOpBuild, llzkPod_WritePodOpBuild,
 };
 use melior::StringRef;
-use melior::ir::attribute::StringAttribute;
 use melior::ir::{
-    Location, Operation, OperationRef, Type, TypeLike, Value, ValueLike,
-    operation::{OperationBuilder, OperationLike},
+    Identifier, Location, OperationRef, Type, TypeLike, Value, ValueLike, operation::OperationLike,
 };
 use std::marker::PhantomData;
 
@@ -107,20 +105,23 @@ pub fn is_pod_new<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates a 'pod.read' operation.
-pub fn read<'c>(
+pub fn read<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     pod_ref: Value<'c, '_>,
     record_name: &str,
     result: Type<'c>,
-) -> Operation<'c> {
+) -> OperationRef<'c, 'a> {
     let ctx = location.context();
-    let record_name = StringAttribute::new(unsafe { ctx.to_ref() }, record_name);
-    OperationBuilder::new("pod.read", location)
-        .add_attributes(&[(ident!(ctx, "record_name"), record_name.into())])
-        .add_operands(&[pod_ref])
-        .add_results(&[result])
-        .build()
-        .expect("valid operation")
+    unsafe {
+        OperationRef::from_raw(llzkPod_ReadPodOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            result.to_raw(),
+            pod_ref.to_raw(),
+            Identifier::new(ctx.to_ref(), record_name).to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `pod.read`.
@@ -130,19 +131,23 @@ pub fn is_pod_read<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates a 'pod.write' operation.
-pub fn write<'c>(
+pub fn write<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     pod_ref: Value<'c, '_>,
     record_name: &str,
     rvalue: Value<'c, '_>,
-) -> Operation<'c> {
+) -> OperationRef<'c, 'a> {
     let ctx = location.context();
-    let record_name = StringAttribute::new(unsafe { ctx.to_ref() }, record_name);
-    OperationBuilder::new("pod.write", location)
-        .add_attributes(&[(ident!(ctx, "record_name"), record_name.into())])
-        .add_operands(&[pod_ref, rvalue])
-        .build()
-        .expect("valid operation")
+    unsafe {
+        OperationRef::from_raw(llzkPod_WritePodOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            pod_ref.to_raw(),
+            rvalue.to_raw(),
+            Identifier::new(ctx.to_ref(), record_name).to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `pod.write`.

--- a/llzk/src/dialect/poly/ops.rs
+++ b/llzk/src/dialect/poly/ops.rs
@@ -4,6 +4,7 @@ use crate::{
     builder::OpBuilderLike,
     error::Error,
     macros::llzk_op_type,
+    operation::detach_and_erase_op,
     value_ext::{OwningValueRange, ValueRange},
 };
 use llzk_sys::{
@@ -170,7 +171,13 @@ where
 
     let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_start(block);
-    fill(builder).map(|_| op)
+    match fill(builder) {
+        Ok(()) => Ok(op),
+        Err(err) => {
+            detach_and_erase_op(op);
+            Err(err)
+        }
+    }
 }
 
 /// Return `true` iff the given op is `poly.template`.
@@ -525,7 +532,13 @@ where
 
     let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_start(block);
-    fill(builder).map(|_| op)
+    match fill(builder) {
+        Ok(()) => Ok(op),
+        Err(err) => {
+            detach_and_erase_op(op);
+            Err(err)
+        }
+    }
 }
 
 /// Return `true` iff the given op is `poly.expr`.

--- a/llzk/src/dialect/poly/ops.rs
+++ b/llzk/src/dialect/poly/ops.rs
@@ -3,14 +3,13 @@
 use crate::{
     builder::OpBuilderLike,
     error::Error,
-    ident,
     macros::llzk_op_type,
     value_ext::{OwningValueRange, ValueRange},
 };
 use llzk_sys::{
     llzkOperationIsA_Poly_TemplateExprOp, llzkOperationIsA_Poly_TemplateOp,
     llzkOperationIsA_Poly_TemplateParamOp, llzkOperationIsA_Poly_YieldOp,
-    llzkPoly_ApplyMapOpBuildWithAffineMap, llzkPoly_TemplateExprOpBuild,
+    llzkPoly_ApplyMapOpBuildWithAffineMap, llzkPoly_ConstReadOpBuild, llzkPoly_TemplateExprOpBuild,
     llzkPoly_TemplateExprOpGetInitializerRegion, llzkPoly_TemplateExprOpGetType,
     llzkPoly_TemplateOpBuild, llzkPoly_TemplateOpGetBody, llzkPoly_TemplateOpGetBodyRegion,
     llzkPoly_TemplateOpGetConstExprNames, llzkPoly_TemplateOpGetConstParamNames,
@@ -18,13 +17,13 @@ use llzk_sys::{
     llzkPoly_TemplateOpHasConstParamNamed, llzkPoly_TemplateOpHasConstParamOps,
     llzkPoly_TemplateOpNumConstExprOps, llzkPoly_TemplateOpNumConstParamOps,
     llzkPoly_TemplateParamOpBuild, llzkPoly_TemplateParamOpGetTypeOpt,
-    llzkPoly_TemplateParamOpSetTypeOpt, llzkPoly_YieldOpBuild,
+    llzkPoly_TemplateParamOpSetTypeOpt, llzkPoly_UnifiableCastOpBuild, llzkPoly_YieldOpBuild,
 };
 use melior::ir::{
     Attribute, AttributeLike, Block, BlockLike as _, BlockRef, Identifier, Location, Operation,
-    OperationRef, RegionLike as _, RegionRef, Type, Value, ValueLike as _,
+    OperationRef, RegionLike as _, RegionRef, Type, TypeLike, Value, ValueLike as _,
     attribute::{FlatSymbolRefAttribute, StringAttribute, TypeAttribute},
-    operation::{OperationBuilder, OperationLike},
+    operation::OperationLike,
 };
 use mlir_sys::MlirAttribute;
 
@@ -142,9 +141,10 @@ impl<'c: 'a, 'a> TemplateOpLike<'c, 'a> for TemplateOp<'c> {}
 impl<'c: 'a, 'a> TemplateOpLike<'c, 'a> for TemplateOpRef<'c, 'a> {}
 impl<'c: 'a, 'a> TemplateOpLike<'c, 'a> for TemplateOpRefMut<'c, 'a> {}
 
-/// Creates a `poly.template` op and fills its body with the given operations.
+/// Creates a `poly.template` op and fills its body with operations produced by the callback.
 ///
-/// The operation is inserted in the point set by the builder.
+/// Use [`crate::dialect::empty_region`] as the `fill` callback to leave the body empty so contents
+/// can be added later.
 pub fn template<'c, 'a, B>(
     builder: &B,
     location: Location<'c>,
@@ -497,14 +497,15 @@ pub fn is_param_op<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
     crate::operation::isa(op, "poly.param")
 }
 
-/// Creates a `poly.expr` op and fills its initializer region with the given operations.
+/// Creates a `poly.expr` op and fills its initializer region with operations produced by the callback.
 ///
-/// The operation is inserted in the point set by the builder.
+/// Use [`crate::dialect::empty_region`] as the `fill` callback to leave the initializer empty so
+/// contents can be added later.
 pub fn expr<'c, 'a, B>(
     builder: &B,
     location: Location<'c>,
     name: &str,
-    fill_cb: impl FnOnce(&B) -> Result<(), Error>,
+    fill: impl FnOnce(&B) -> Result<(), Error>,
 ) -> Result<TemplateExprOpRef<'c, 'a>, Error>
 where
     B: OpBuilderLike<'c>,
@@ -524,7 +525,7 @@ where
         .unwrap_or_else(|| region.append_block(Block::new(&[])));
     let prev = builder.save_insertion_point();
     builder.set_insertion_point_at_start(block);
-    let res = fill_cb(builder);
+    let res = fill(builder);
     builder.restore_insertion_point(prev);
     res.map(|_| op)
 }
@@ -542,8 +543,6 @@ pub fn is_expr_op<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 llzk_op_type!(YieldOp, llzkOperationIsA_Poly_YieldOp, "poly.yield");
 
 /// Creates a `poly.yield` op.
-///
-/// The operation is inserted in the point set by the builder.
 pub fn r#yield<'c, 'a>(
     builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
@@ -570,16 +569,21 @@ pub fn is_yield_op<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 //===----------------------------------------------------------------------===//
 
 /// Constructs a 'poly.read_const' operation.
-pub fn read_const<'c>(location: Location<'c>, symbol: &str, result: Type<'c>) -> Operation<'c> {
+pub fn read_const<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    symbol: &str,
+    result: Type<'c>,
+) -> OperationRef<'c, 'a> {
     let ctx = location.context();
-    OperationBuilder::new("poly.read_const", location)
-        .add_attributes(&[(
-            ident!(ctx, "const_name"),
-            FlatSymbolRefAttribute::new(unsafe { ctx.to_ref() }, symbol).into(),
-        )])
-        .add_results(&[result])
-        .build()
-        .expect("valid operation")
+    unsafe {
+        OperationRef::from_raw(llzkPoly_ConstReadOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            result.to_raw(),
+            FlatSymbolRefAttribute::new(ctx.to_ref(), symbol).to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `poly.read_const`.
@@ -593,16 +597,20 @@ pub fn is_read_const_op<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 //===----------------------------------------------------------------------===//
 
 /// Constructs a 'poly.unifiable_cast' operation.
-pub fn unifiable_cast<'c>(
+pub fn unifiable_cast<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     input: Value<'c, '_>,
     result: Type<'c>,
-) -> Operation<'c> {
-    OperationBuilder::new("poly.unifiable_cast", location)
-        .add_operands(&[input])
-        .add_results(&[result])
-        .build()
-        .expect("valid operation")
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkPoly_UnifiableCastOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            result.to_raw(),
+            input.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `poly.unifiable_cast`.

--- a/llzk/src/dialect/poly/ops.rs
+++ b/llzk/src/dialect/poly/ops.rs
@@ -167,11 +167,10 @@ where
     let block = region
         .first_block()
         .unwrap_or_else(|| region.append_block(Block::new(&[])));
-    let saved = builder.save_insertion_point();
+
+    let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_start(block);
-    let res = fill(builder);
-    builder.restore_insertion_point(saved);
-    res.map(|_| op)
+    fill(builder).map(|_| op)
 }
 
 /// Return `true` iff the given op is `poly.template`.
@@ -523,11 +522,10 @@ where
     let block = region
         .first_block()
         .unwrap_or_else(|| region.append_block(Block::new(&[])));
-    let prev = builder.save_insertion_point();
+
+    let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_start(block);
-    let res = fill(builder);
-    builder.restore_insertion_point(prev);
-    res.map(|_| op)
+    fill(builder).map(|_| op)
 }
 
 /// Return `true` iff the given op is `poly.expr`.

--- a/llzk/src/dialect/poly/ops.rs
+++ b/llzk/src/dialect/poly/ops.rs
@@ -164,6 +164,7 @@ where
         ))
     };
     let op: TemplateOpRef<'c, 'a> = op.try_into()?;
+
     let region = op.body_region();
     let block = region
         .first_block()
@@ -525,6 +526,7 @@ where
         ))
     };
     let op: TemplateExprOpRef<'c, 'a> = op.try_into()?;
+
     let region = op.initializer_region();
     let block = region
         .first_block()

--- a/llzk/src/dialect/ram/ops.rs
+++ b/llzk/src/dialect/ram/ops.rs
@@ -1,26 +1,28 @@
 //! `ram` dialect operations.
 
-use melior::ir::{
-    Location, Operation, Value,
-    operation::{OperationBuilder, OperationLike},
-};
-
+use crate::builder::OpBuilderLike;
 use crate::dialect::felt::FeltType;
+use llzk_sys::{llzkRam_LoadOpBuild, llzkRam_StoreOpBuild};
+use melior::ir::{Location, OperationRef, TypeLike, Value, ValueLike, operation::OperationLike};
 
 /// Creates a `ram.load` operation with the given target `FeltType` or the
 /// default "unspecified prime" `FeltType` if `None` is provided.
-pub fn load<'c>(
+pub fn load<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     addr: Value<'c, '_>,
     out_type: Option<FeltType<'c>>,
-) -> Operation<'c> {
+) -> OperationRef<'c, 'a> {
     let ctx = location.context();
     let out_type = out_type.unwrap_or_else(|| FeltType::new(unsafe { ctx.to_ref() }));
-    OperationBuilder::new("ram.load", location)
-        .add_operands(&[addr])
-        .add_results(&[out_type.into()])
-        .build()
-        .expect("valid operation")
+    unsafe {
+        OperationRef::from_raw(llzkRam_LoadOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            out_type.to_raw(),
+            addr.to_raw(),
+        ))
+    }
 }
 
 /// Returns `true` iff the given op is `ram.load`.
@@ -32,11 +34,20 @@ pub fn is_ram_load<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 /// Creates a `ram.store` operation.
 ///
 /// Writes a value to the flat memory region at the given address.
-pub fn store<'c>(location: Location<'c>, addr: Value<'c, '_>, val: Value<'c, '_>) -> Operation<'c> {
-    OperationBuilder::new("ram.store", location)
-        .add_operands(&[addr, val])
-        .build()
-        .expect("valid operation")
+pub fn store<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    addr: Value<'c, '_>,
+    val: Value<'c, '_>,
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkRam_StoreOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            addr.to_raw(),
+            val.to_raw(),
+        ))
+    }
 }
 
 /// Returns `true` iff the given op is `ram.store`.

--- a/llzk/src/dialect/ram/tests.rs
+++ b/llzk/src/dialect/ram/tests.rs
@@ -63,6 +63,7 @@ fn build_fn<'c, 'm>(
         FunctionType::new(ctx, &[], &[]),
         &[],
         None,
+        crate::dialect::empty_region,
     )
     .unwrap();
     configure(&f);
@@ -70,7 +71,8 @@ fn build_fn<'c, 'm>(
     let block = f
         .body()
         .expect("function.def must have a body")
-        .append_block(melior::ir::Block::new(&[]));
+        .first_block()
+        .expect("function.def must have an entry block");
     builder.set_insertion_point_at_start(block);
     build(&builder);
     crate::dialect::function::r#return(&builder, location, &[]);

--- a/llzk/src/dialect/ram/tests.rs
+++ b/llzk/src/dialect/ram/tests.rs
@@ -1,15 +1,6 @@
-use melior::{
-    Context,
-    ir::{
-        Block, BlockLike, Location, Module, RegionLike, Type, Value,
-        attribute::IntegerAttribute,
-        operation::{OperationLike, OperationRef},
-        r#type::FunctionType,
-    },
-};
-use rstest::rstest;
-
+use super::ops;
 use crate::{
+    builder::{OpBuilder, OpBuilderLike},
     dialect::{
         felt::{FeltConstAttribute, FeltType},
         function::FuncDefOpLike,
@@ -17,8 +8,16 @@ use crate::{
     },
     test::ctx,
 };
-
-use super::ops;
+use melior::{
+    Context,
+    ir::{
+        Location, Module, RegionLike as _, Type, Value,
+        attribute::IntegerAttribute,
+        operation::{OperationLike as _, OperationRef},
+        r#type::FunctionType,
+    },
+};
+use rstest::rstest;
 
 /// Helper: wraps operations inside a `function.def` with `allow_witness` so
 /// that RAM ops pass verification. Asserts verification succeeds.
@@ -26,7 +25,7 @@ fn witness_fn_passes<'c>(
     module: &Module<'c>,
     ctx: &'c Context,
     location: Location<'c>,
-    build: impl FnOnce(&Block<'c>),
+    build: impl FnOnce(&OpBuilder<'c, '_>),
 ) {
     let f = build_fn(module, ctx, location, build, |f| {
         f.set_allow_witness_attr(true);
@@ -41,7 +40,7 @@ fn constraint_fn_rejected<'c>(
     module: &Module<'c>,
     ctx: &'c Context,
     location: Location<'c>,
-    build: impl FnOnce(&Block<'c>),
+    build: impl FnOnce(&OpBuilder<'c, '_>),
 ) {
     let f = build_fn(module, ctx, location, build, |f| {
         f.set_allow_constraint_attr(true);
@@ -53,10 +52,12 @@ fn build_fn<'c, 'm>(
     module: &'m Module<'c>,
     ctx: &'c Context,
     location: Location<'c>,
-    build: impl FnOnce(&Block<'c>),
-    configure: impl FnOnce(&crate::dialect::function::FuncDefOp<'c>),
+    build: impl FnOnce(&OpBuilder<'c, '_>),
+    configure: impl FnOnce(&crate::dialect::function::FuncDefOpRef<'c, 'm>),
 ) -> OperationRef<'c, 'm> {
+    let builder = OpBuilder::at_block_end(ctx, module.body());
     let f = crate::dialect::function::def(
+        &builder,
         location,
         "test_fn",
         FunctionType::new(ctx, &[], &[]),
@@ -66,52 +67,52 @@ fn build_fn<'c, 'm>(
     .unwrap();
     configure(&f);
 
-    let block = Block::new(&[]);
-    build(&block);
-    block.append_operation(crate::dialect::function::r#return(location, &[]));
-    f.region(0)
-        .expect("function.def must have a region")
-        .append_block(block);
+    let block = f
+        .body()
+        .expect("function.def must have a body")
+        .append_block(melior::ir::Block::new(&[]));
+    builder.set_insertion_point_at_start(block);
+    build(&builder);
+    crate::dialect::function::r#return(&builder, location, &[]);
 
-    module.body().append_operation(f.into())
+    f.into()
 }
 
-fn build_addr<'c, 'b>(
-    block: &'b Block<'c>,
-    ctx: &'c Context,
+fn build_addr<'c: 'a, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     value: i64,
-) -> Value<'c, 'b> {
-    let addr_op = block.append_operation(melior::dialect::arith::constant(
-        ctx,
-        IntegerAttribute::new(Type::index(ctx), value).into(),
-        location,
-    ));
+) -> Value<'c, 'a> {
+    let addr_op = builder.insert(location, |ctx, location| {
+        melior::dialect::arith::constant(
+            ctx,
+            IntegerAttribute::new(Type::index(ctx), value).into(),
+            location,
+        )
+    });
     addr_op.result(0).unwrap().into()
 }
 
-fn build_load<'c, 'b>(
-    block: &'b Block<'c>,
-    ctx: &'c Context,
+fn build_load<'c: 'a, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
-) -> OperationRef<'c, 'b> {
-    let addr = build_addr(block, ctx, location, 42);
-    block.append_operation(ops::load(location, addr, None))
+) -> OperationRef<'c, 'a> {
+    let addr = build_addr(builder, location, 42);
+    ops::load(builder, location, addr, None)
 }
 
-fn build_store<'c, 'b>(
-    block: &'b Block<'c>,
+fn build_store<'c: 'a, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     ctx: &'c Context,
     location: Location<'c>,
-) -> OperationRef<'c, 'b> {
-    let addr = build_addr(block, ctx, location, 0);
-    let val_op = block.append_operation(
-        crate::dialect::felt::constant(location, FeltConstAttribute::new(ctx, 99, None))
-            .expect("valid felt.const"),
-    );
+) -> OperationRef<'c, 'a> {
+    let addr = build_addr(builder, location, 0);
+    let val_op =
+        crate::dialect::felt::constant(builder, location, FeltConstAttribute::new(ctx, 99, None))
+            .expect("valid felt.const");
     let val: Value = val_op.result(0).unwrap().into();
 
-    block.append_operation(ops::store(location, addr, val))
+    ops::store(builder, location, addr, val)
 }
 
 #[rstest]
@@ -119,8 +120,8 @@ fn op_load(ctx: Context) {
     let location = Location::unknown(&ctx);
     let module = llzk_module(location, None);
 
-    witness_fn_passes(&module, &ctx, location, |block| {
-        let load = build_load(block, &ctx, location);
+    witness_fn_passes(&module, &ctx, location, |builder| {
+        let load = build_load(builder, location);
         assert!(ops::is_ram_load(&load));
     });
 }
@@ -130,8 +131,8 @@ fn op_store(ctx: Context) {
     let location = Location::unknown(&ctx);
     let module = llzk_module(location, None);
 
-    witness_fn_passes(&module, &ctx, location, |block| {
-        let store = build_store(block, &ctx, location);
+    witness_fn_passes(&module, &ctx, location, |builder| {
+        let store = build_store(builder, &ctx, location);
         assert!(ops::is_ram_store(&store));
     });
 }
@@ -141,10 +142,10 @@ fn op_load_with_specified_field(ctx: Context) {
     let location = Location::unknown(&ctx);
     let module = llzk_module(location, None);
 
-    witness_fn_passes(&module, &ctx, location, |block| {
-        let addr = build_addr(block, &ctx, location, 42);
+    witness_fn_passes(&module, &ctx, location, |builder| {
+        let addr = build_addr(builder, location, 42);
         let felt_ty = FeltType::with_field(&ctx, "bn254");
-        let load = block.append_operation(ops::load(location, addr, Some(felt_ty)));
+        let load = ops::load(builder, location, addr, Some(felt_ty));
         assert!(ops::is_ram_load(&load));
     });
 }
@@ -154,8 +155,8 @@ fn op_load_rejected_in_constraint_fn(ctx: Context) {
     let location = Location::unknown(&ctx);
     let module = llzk_module(location, None);
 
-    constraint_fn_rejected(&module, &ctx, location, |block| {
-        build_load(block, &ctx, location);
+    constraint_fn_rejected(&module, &ctx, location, |builder| {
+        build_load(builder, location);
     });
 }
 
@@ -164,7 +165,7 @@ fn op_store_rejected_in_constraint_fn(ctx: Context) {
     let location = Location::unknown(&ctx);
     let module = llzk_module(location, None);
 
-    constraint_fn_rejected(&module, &ctx, location, |block| {
-        build_store(block, &ctx, location);
+    constraint_fn_rejected(&module, &ctx, location, |builder| {
+        build_store(builder, &ctx, location);
     });
 }

--- a/llzk/src/dialect/struct/helpers.rs
+++ b/llzk/src/dialect/struct/helpers.rs
@@ -1,5 +1,16 @@
 //! Convenience functions for creating common operation patterns.
 
+use super::r#type::StructType;
+use crate::{
+    attributes::NamedAttribute,
+    builder::{EntryPoint, OpBuilder, OpBuilderLike},
+    dialect,
+    error::Error,
+    prelude::{
+        FUNC_NAME_COMPUTE, FUNC_NAME_CONSTRAIN, FUNC_NAME_PRODUCT, FeltType, FuncDefOpLike as _,
+        FuncDefOpRef, StructDefOp,
+    },
+};
 use melior::{
     Context,
     ir::{
@@ -8,29 +19,18 @@ use melior::{
     },
 };
 
-use crate::{
-    attributes::NamedAttribute,
-    builder::{EntryPoint, OpBuilder, OpBuilderLike},
-    dialect,
-    error::Error,
-    prelude::{
-        FUNC_NAME_COMPUTE, FUNC_NAME_CONSTRAIN, FUNC_NAME_PRODUCT, FeltType, FuncDefOp,
-        FuncDefOpLike as _, StructDefOp,
-    },
-};
-
-use super::r#type::StructType;
-
 /// Creates an empty `@compute` function with the configuration expected by `struct.def`.
-pub fn compute_fn<'c>(
+pub fn compute_fn<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     loc: Location<'c>,
     struct_type: StructType<'c>,
     inputs: &[(Type<'c>, Location<'c>)],
     arg_attrs: Option<&[Vec<NamedAttribute<'c>>]>,
-) -> Result<FuncDefOp<'c>, Error> {
+) -> Result<FuncDefOpRef<'c, 'a>, Error> {
     let context = loc.context();
     let input_types: Vec<Type<'c>> = inputs.iter().map(|(t, _)| *t).collect();
     dialect::function::def(
+        builder,
         loc,
         FUNC_NAME_COMPUTE.as_ref(),
         FunctionType::new(
@@ -43,14 +43,12 @@ pub fn compute_fn<'c>(
     )
     .and_then(|f| {
         let block = Block::new(inputs);
-        let new_struct = block.append_operation(super::new(loc, struct_type));
-        block.append_operation(dialect::function::r#return(
-            loc,
-            &[new_struct.result(0)?.into()],
-        ));
+        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, &block);
+        let new_struct = super::new(&inner_bldr, loc, struct_type);
+        dialect::function::r#return(&inner_bldr, loc, &[new_struct.result(0)?.into()]);
         f.set_allow_witness_attr(true);
         f.set_allow_non_native_field_ops_attr(true);
-        f.region(0)?.append_block(block);
+        f.body()?.append_block(block);
         Ok(f)
     })
 }
@@ -59,12 +57,13 @@ pub fn compute_fn<'c>(
 ///
 /// If `arg_attrs` is `Some` it must have `inputs.len() + 1` elements and element #0 is the
 /// argument attributes of the self argument.
-pub fn constrain_fn<'c>(
+pub fn constrain_fn<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     loc: Location<'c>,
     struct_type: StructType<'c>,
     inputs: &[(Type<'c>, Location<'c>)],
     arg_attrs: Option<&[Vec<NamedAttribute<'c>>]>,
-) -> Result<FuncDefOp<'c>, Error> {
+) -> Result<FuncDefOpRef<'c, 'a>, Error> {
     let context = loc.context();
     let mut input_types: Vec<Type<'c>> = Vec::with_capacity(inputs.len() + 1);
     input_types.push(struct_type.into());
@@ -77,6 +76,7 @@ pub fn constrain_fn<'c>(
         result
     });
     dialect::function::def(
+        builder,
         loc,
         FUNC_NAME_CONSTRAIN.as_ref(),
         FunctionType::new(unsafe { context.to_ref() }, &input_types, &[]),
@@ -85,24 +85,27 @@ pub fn constrain_fn<'c>(
     )
     .and_then(|f| {
         let block = Block::new(&all_inputs);
-        block.append_operation(dialect::function::r#return(loc, &[]));
+        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, &block);
+        dialect::function::r#return(&inner_bldr, loc, &[]);
         f.set_allow_constraint_attr(true);
         f.set_allow_non_native_field_ops_attr(true);
-        f.region(0)?.append_block(block);
+        f.body()?.append_block(block);
         Ok(f)
     })
 }
 
 /// Creates an empty `@product` function with the configuration expected by `struct.def`.
-pub fn product_fn<'c>(
+pub fn product_fn<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     loc: Location<'c>,
     struct_type: StructType<'c>,
     inputs: &[(Type<'c>, Location<'c>)],
     arg_attrs: Option<&[Vec<NamedAttribute<'c>>]>,
-) -> Result<FuncDefOp<'c>, Error> {
+) -> Result<FuncDefOpRef<'c, 'a>, Error> {
     let context = loc.context();
     let input_types: Vec<Type<'c>> = inputs.iter().map(|(t, _)| *t).collect();
     dialect::function::def(
+        builder,
         loc,
         FUNC_NAME_PRODUCT.as_ref(),
         FunctionType::new(
@@ -115,15 +118,13 @@ pub fn product_fn<'c>(
     )
     .and_then(|f| {
         let block = Block::new(inputs);
-        let new_struct = block.append_operation(super::new(loc, struct_type));
-        block.append_operation(dialect::function::r#return(
-            loc,
-            &[new_struct.result(0)?.into()],
-        ));
+        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, &block);
+        let new_struct = super::new(&inner_bldr, loc, struct_type);
+        dialect::function::r#return(&inner_bldr, loc, &[new_struct.result(0)?.into()]);
         f.set_allow_constraint_attr(true);
         f.set_allow_witness_attr(true);
         f.set_allow_non_native_field_ops_attr(true);
-        f.region(0)?.append_block(block);
+        f.body()?.append_block(block);
         Ok(f)
     })
 }
@@ -136,62 +137,76 @@ pub fn define_signal_struct<'c>(context: &'c Context) -> Result<StructDefOp<'c>,
     let loc = Location::new(context, "Signal struct", 0, 0);
     let typ = StructType::from_str(context, "Signal");
     let reg = "reg";
-    super::def(loc, "Signal", {
-        [
-            super::member(loc, reg, FeltType::new(context), true, false, true).map(Into::into),
-            compute_fn(loc, typ, &[(FeltType::new(context).into(), loc)], None)
-                .and_then(|compute| {
-                    let block = compute
-                        .region(0)?
-                        .first_block()
-                        .ok_or(Error::BlockExpected(0))?;
-                    let fst = block.first_operation().ok_or(Error::EmptyBlock)?;
-                    if fst.name() != Identifier::new(context, "struct.new") {
-                        return Err(Error::OperationExpected(
-                            "struct.new",
-                            fst.name().as_string_ref().as_str()?.to_owned(),
-                        ));
-                    }
-                    block.insert_operation_after(
-                        fst,
-                        super::writem(loc, fst.result(0)?.into(), reg, block.argument(0)?.into())?,
-                    );
-                    Ok(compute)
-                })
-                .map(Into::into),
-            constrain_fn(loc, typ, &[(FeltType::new(context).into(), loc)], None)
-                .and_then(|constrain| {
-                    let block = constrain
-                        .region(0)?
-                        .first_block()
-                        .ok_or(Error::BlockExpected(0))?;
-                    let fst = block.first_operation().ok_or(Error::EmptyBlock)?;
-                    if fst.name() != Identifier::new(context, "function.return") {
-                        return Err(Error::OperationExpected(
-                            "function.return",
-                            fst.name().as_string_ref().as_str()?.to_owned(),
-                        ));
-                    }
-                    let builder = OpBuilder::new(context, EntryPoint::Before(fst));
-                    let reg = super::readm(
-                        &builder,
-                        loc,
-                        FeltType::new(context).into(),
-                        block.argument(0)?.into(),
-                        "reg",
-                    )?;
-                    builder.set_insertion_point_after(reg);
-                    block.insert_operation_after(
-                        reg,
-                        dialect::constrain::eq(
-                            loc,
-                            reg.result(0)?.into(),
-                            block.argument(1)?.into(),
-                        ),
-                    );
-                    Ok(constrain)
-                })
-                .map(Into::into),
-        ]
-    })
+    let block = Block::new(&[]);
+    let builder = OpBuilder::at_block_begin(context, &block);
+    let op = super::def(&builder, loc, "Signal", |builder| {
+        super::member(builder, loc, reg, FeltType::new(context), true, false, true)?;
+        compute_fn(
+            builder,
+            loc,
+            typ,
+            &[(FeltType::new(context).into(), loc)],
+            None,
+        )
+        .and_then(|compute| {
+            let block = compute
+                .body()?
+                .first_block()
+                .ok_or(Error::BlockExpected(0))?;
+            let fst = block.first_operation().ok_or(Error::EmptyBlock)?;
+            if fst.name() != Identifier::new(context, "struct.new") {
+                return Err(Error::OperationExpected(
+                    "struct.new",
+                    fst.name().as_string_ref().as_str()?.to_owned(),
+                ));
+            }
+            let builder = OpBuilder::new(context, EntryPoint::After(fst));
+            super::writem(
+                &builder,
+                loc,
+                fst.result(0)?.into(),
+                reg,
+                block.argument(0)?.into(),
+            )?;
+            Ok(compute)
+        })?;
+        constrain_fn(
+            builder,
+            loc,
+            typ,
+            &[(FeltType::new(context).into(), loc)],
+            None,
+        )
+        .and_then(|constrain| {
+            let block = constrain
+                .body()?
+                .first_block()
+                .ok_or(Error::BlockExpected(0))?;
+            let fst = block.first_operation().ok_or(Error::EmptyBlock)?;
+            if fst.name() != Identifier::new(context, "function.return") {
+                return Err(Error::OperationExpected(
+                    "function.return",
+                    fst.name().as_string_ref().as_str()?.to_owned(),
+                ));
+            }
+            let builder = OpBuilder::new(context, EntryPoint::Before(fst));
+            let reg = super::readm(
+                &builder,
+                loc,
+                FeltType::new(context).into(),
+                block.argument(0)?.into(),
+                "reg",
+            )?;
+            builder.set_insertion_point_after(reg);
+            dialect::constrain::eq(
+                &builder,
+                loc,
+                reg.result(0)?.into(),
+                block.argument(1)?.into(),
+            );
+            Ok(constrain)
+        })?;
+        Ok(())
+    })?;
+    Ok(unsafe { op.to_ref() }.clone())
 }

--- a/llzk/src/dialect/struct/helpers.rs
+++ b/llzk/src/dialect/struct/helpers.rs
@@ -40,15 +40,15 @@ pub fn compute_fn<'c, 'a>(
         ),
         &[],
         arg_attrs,
+        dialect::empty_region,
     )
     .and_then(|f| {
-        let block = Block::new(inputs);
-        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, &block);
+        let block = f.body()?.first_block().ok_or(Error::EmptyBlock)?;
+        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, block);
         let new_struct = super::new(&inner_bldr, loc, struct_type);
         dialect::function::r#return(&inner_bldr, loc, &[new_struct.result(0)?.into()]);
         f.set_allow_witness_attr(true);
         f.set_allow_non_native_field_ops_attr(true);
-        f.body()?.append_block(block);
         Ok(f)
     })
 }
@@ -68,8 +68,6 @@ pub fn constrain_fn<'c, 'a>(
     let mut input_types: Vec<Type<'c>> = Vec::with_capacity(inputs.len() + 1);
     input_types.push(struct_type.into());
     input_types.extend(inputs.iter().map(|(t, _)| *t));
-    let mut all_inputs = vec![(struct_type.into(), loc)];
-    all_inputs.extend(inputs);
     let all_arg_attrs = arg_attrs.map(|original| {
         let mut result: Vec<Vec<(Identifier<'_>, Attribute<'_>)>> = vec![vec![]];
         result.extend(original.iter().cloned());
@@ -82,14 +80,14 @@ pub fn constrain_fn<'c, 'a>(
         FunctionType::new(unsafe { context.to_ref() }, &input_types, &[]),
         &[],
         all_arg_attrs.as_deref(),
+        dialect::empty_region,
     )
     .and_then(|f| {
-        let block = Block::new(&all_inputs);
-        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, &block);
+        let block = f.body()?.first_block().ok_or(Error::EmptyBlock)?;
+        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, block);
         dialect::function::r#return(&inner_bldr, loc, &[]);
         f.set_allow_constraint_attr(true);
         f.set_allow_non_native_field_ops_attr(true);
-        f.body()?.append_block(block);
         Ok(f)
     })
 }
@@ -115,16 +113,16 @@ pub fn product_fn<'c, 'a>(
         ),
         &[],
         arg_attrs,
+        dialect::empty_region,
     )
     .and_then(|f| {
-        let block = Block::new(inputs);
-        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, &block);
+        let block = f.body()?.first_block().ok_or(Error::EmptyBlock)?;
+        let inner_bldr = OpBuilder::at_block_begin(unsafe { context.to_ref() }, block);
         let new_struct = super::new(&inner_bldr, loc, struct_type);
         dialect::function::r#return(&inner_bldr, loc, &[new_struct.result(0)?.into()]);
         f.set_allow_constraint_attr(true);
         f.set_allow_witness_attr(true);
         f.set_allow_non_native_field_ops_attr(true);
-        f.body()?.append_block(block);
         Ok(f)
     })
 }

--- a/llzk/src/dialect/struct/helpers.rs
+++ b/llzk/src/dialect/struct/helpers.rs
@@ -3,21 +3,14 @@
 use super::r#type::StructType;
 use crate::{
     attributes::NamedAttribute,
-    builder::{EntryPoint, OpBuilder, OpBuilderLike},
+    builder::{OpBuilder, OpBuilderLike},
     dialect,
     error::Error,
     prelude::{
-        FUNC_NAME_COMPUTE, FUNC_NAME_CONSTRAIN, FUNC_NAME_PRODUCT, FeltType, FuncDefOpLike as _,
-        FuncDefOpRef, StructDefOp,
+        FUNC_NAME_COMPUTE, FUNC_NAME_CONSTRAIN, FUNC_NAME_PRODUCT, FuncDefOpLike as _, FuncDefOpRef,
     },
 };
-use melior::{
-    Context,
-    ir::{
-        Attribute, Block, BlockLike as _, Identifier, Location, RegionLike as _, Type,
-        operation::OperationLike as _, r#type::FunctionType,
-    },
-};
+use melior::ir::{Attribute, Identifier, Location, RegionLike as _, Type, r#type::FunctionType};
 
 /// Creates an empty `@compute` function with the configuration expected by `struct.def`.
 pub fn compute_fn<'c, 'a>(
@@ -125,86 +118,4 @@ pub fn product_fn<'c, 'a>(
         f.set_allow_non_native_field_ops_attr(true);
         Ok(f)
     })
-}
-
-/// Creates the `@Signal` struct.
-///
-/// The `@Main` struct's inputs must be of this type or arrays of this type.
-#[deprecated]
-pub fn define_signal_struct<'c>(context: &'c Context) -> Result<StructDefOp<'c>, Error> {
-    let loc = Location::new(context, "Signal struct", 0, 0);
-    let typ = StructType::from_str(context, "Signal");
-    let reg = "reg";
-    let block = Block::new(&[]);
-    let builder = OpBuilder::at_block_begin(context, &block);
-    let op = super::def(&builder, loc, "Signal", |builder| {
-        super::member(builder, loc, reg, FeltType::new(context), true, false, true)?;
-        compute_fn(
-            builder,
-            loc,
-            typ,
-            &[(FeltType::new(context).into(), loc)],
-            None,
-        )
-        .and_then(|compute| {
-            let block = compute
-                .body()?
-                .first_block()
-                .ok_or(Error::BlockExpected(0))?;
-            let fst = block.first_operation().ok_or(Error::EmptyBlock)?;
-            if fst.name() != Identifier::new(context, "struct.new") {
-                return Err(Error::OperationExpected(
-                    "struct.new",
-                    fst.name().as_string_ref().as_str()?.to_owned(),
-                ));
-            }
-            let builder = OpBuilder::new(context, EntryPoint::After(fst));
-            super::writem(
-                &builder,
-                loc,
-                fst.result(0)?.into(),
-                reg,
-                block.argument(0)?.into(),
-            )?;
-            Ok(compute)
-        })?;
-        constrain_fn(
-            builder,
-            loc,
-            typ,
-            &[(FeltType::new(context).into(), loc)],
-            None,
-        )
-        .and_then(|constrain| {
-            let block = constrain
-                .body()?
-                .first_block()
-                .ok_or(Error::BlockExpected(0))?;
-            let fst = block.first_operation().ok_or(Error::EmptyBlock)?;
-            if fst.name() != Identifier::new(context, "function.return") {
-                return Err(Error::OperationExpected(
-                    "function.return",
-                    fst.name().as_string_ref().as_str()?.to_owned(),
-                ));
-            }
-            let builder = OpBuilder::new(context, EntryPoint::Before(fst));
-            let reg = super::readm(
-                &builder,
-                loc,
-                FeltType::new(context).into(),
-                block.argument(0)?.into(),
-                "reg",
-            )?;
-            builder.set_insertion_point_after(reg);
-            dialect::constrain::eq(
-                &builder,
-                loc,
-                reg.result(0)?.into(),
-                block.argument(1)?.into(),
-            );
-            Ok(constrain)
-        })?;
-        Ok(())
-    })?;
-    Ok(unsafe { op.to_ref() }.clone())
 }

--- a/llzk/src/dialect/struct/ops.rs
+++ b/llzk/src/dialect/struct/ops.rs
@@ -415,11 +415,10 @@ where
         Some(block) => block,
         None => region.append_block(Block::new(&[])),
     };
-    let saved = builder.save_insertion_point();
+
+    let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_start(block);
-    let res = fill(builder);
-    builder.restore_insertion_point(saved);
-    res.map(|_| op)
+    fill(builder).map(|_| op)
 }
 
 /// Return `true` iff the given op is `struct.def`.

--- a/llzk/src/dialect/struct/ops.rs
+++ b/llzk/src/dialect/struct/ops.rs
@@ -411,11 +411,11 @@ where
         ))
     };
     let op: StructDefOpRef<'c, 'a> = op.try_into()?;
+
     let region = op.body_region();
-    let block = match region.first_block() {
-        Some(block) => block,
-        None => region.append_block(Block::new(&[])),
-    };
+    let block = region
+        .first_block()
+        .unwrap_or_else(|| region.append_block(Block::new(&[])));
 
     let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_start(block);

--- a/llzk/src/dialect/struct/ops.rs
+++ b/llzk/src/dialect/struct/ops.rs
@@ -4,6 +4,7 @@ use crate::{
     dialect::function::FuncDefOpRef,
     error::Error,
     macros::llzk_op_type,
+    operation::detach_and_erase_op,
     prelude::SymbolRefAttribute,
 };
 use llzk_sys::{
@@ -418,7 +419,13 @@ where
 
     let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_start(block);
-    fill(builder).map(|_| op)
+    match fill(builder) {
+        Ok(()) => Ok(op),
+        Err(err) => {
+            detach_and_erase_op(op);
+            Err(err)
+        }
+    }
 }
 
 /// Return `true` iff the given op is `struct.def`.

--- a/llzk/src/dialect/struct/ops.rs
+++ b/llzk/src/dialect/struct/ops.rs
@@ -1,9 +1,19 @@
+use super::StructType;
+use crate::{
+    builder::{OpBuilder, OpBuilderLike},
+    dialect::function::FuncDefOpRef,
+    error::Error,
+    macros::llzk_op_type,
+    prelude::SymbolRefAttribute,
+};
 use llzk_sys::{
     llzkOperationIsA_Struct_MemberDefOp, llzkOperationIsA_Struct_StructDefOp,
+    llzkStruct_CreateStructOpBuild, llzkStruct_MemberDefOpBuild,
     llzkStruct_MemberDefOpGetColumnValue, llzkStruct_MemberDefOpGetSignalValue,
     llzkStruct_MemberDefOpHasPublicAttr, llzkStruct_MemberDefOpSetColumnValue,
     llzkStruct_MemberDefOpSetPublicAttr, llzkStruct_MemberDefOpSetSignalValue,
-    llzkStruct_MemberReadOpBuild, llzkStruct_StructDefOpGetBody,
+    llzkStruct_MemberReadOpBuild, llzkStruct_MemberReadOpBuildWithLiteralDistance,
+    llzkStruct_MemberWriteOpBuild, llzkStruct_StructDefOpBuild, llzkStruct_StructDefOpGetBody,
     llzkStruct_StructDefOpGetBodyRegion, llzkStruct_StructDefOpGetComputeFuncOp,
     llzkStruct_StructDefOpGetConstrainFuncOp, llzkStruct_StructDefOpGetFullyQualifiedName,
     llzkStruct_StructDefOpGetMemberDef, llzkStruct_StructDefOpGetMemberDefs,
@@ -13,20 +23,16 @@ use llzk_sys::{
     llzkStruct_StructDefOpGetType, llzkStruct_StructDefOpGetTypeWithParams,
     llzkStruct_StructDefOpHasColumns, llzkStruct_StructDefOpIsMainComponent,
 };
-use melior::ir::{
-    Attribute, AttributeLike, Block, BlockLike as _, BlockRef, Identifier, Location, Operation,
-    OperationRef, Region, RegionLike as _, RegionRef, Type, TypeLike, Value, ValueLike,
-    attribute::{ArrayAttribute, FlatSymbolRefAttribute, StringAttribute, TypeAttribute},
-    operation::{OperationBuilder, OperationLike, OperationMutLike},
+use melior::{
+    StringRef,
+    ir::{
+        Attribute, AttributeLike as _, Block, BlockRef, Identifier, Location, OperationRef,
+        RegionLike as _, RegionRef, Type, TypeLike as _, Value, ValueLike as _,
+        attribute::{ArrayAttribute, FlatSymbolRefAttribute, StringAttribute, TypeAttribute},
+        operation::{OperationLike, OperationMutLike},
+    },
 };
 use mlir_sys::{MlirAttribute, MlirOperation};
-
-use crate::{
-    builder::OpBuilderLike, dialect::function::FuncDefOpRef, error::Error, ident,
-    macros::llzk_op_type, prelude::SymbolRefAttribute,
-};
-
-use super::StructType;
 
 //===----------------------------------------------------------------------===//
 // StructDefOpLike
@@ -111,28 +117,25 @@ pub trait StructDefOpLike<'c: 'a, 'a>: OperationLike<'c, 'a> {
     fn find_or_create_member_def<F>(
         &self,
         name: &str,
-        f: F,
+        build_member_def: F,
     ) -> Result<MemberDefOpRef<'c, 'a>, Error>
     where
-        F: FnOnce() -> Result<MemberDefOp<'c>, Error>,
+        F: FnOnce(&OpBuilder<'c, '_>) -> Result<MemberDefOpRef<'c, 'a>, Error>,
     {
         match self.find_member_def(name) {
             Some(f) => Ok(f),
             None => {
-                let op = f()?;
-                let region = self.region(0)?;
+                let region = self.body_region();
                 let block = region
                     .first_block()
                     .unwrap_or_else(|| region.append_block(Block::new(&[])));
-
-                let member_ref = block.append_operation(op.into());
-
-                Ok(member_ref.try_into()?)
+                let builder = OpBuilder::at_block_end(unsafe { self.context().to_ref() }, block);
+                build_member_def(&builder)
             }
         }
     }
 
-    /// Returns a vector of MemberDefOp operations inside this struct.
+    /// Returns a vector of the member definitions inside this struct.
     ///
     /// # Panics
     ///
@@ -385,34 +388,38 @@ impl<'a, 'c: 'a> MemberDefOpLike<'c, 'a> for MemberDefOpRefMut<'c, 'a> {}
 // Operation factories
 //===----------------------------------------------------------------------===//
 
-/// Creates a 'struct.def' op
-pub fn def<'c, I>(
+/// Creates a 'struct.def' op and fills its body with operations produced by the callback.
+///
+/// Use [`crate::dialect::empty_region`] as the `fill` callback to leave the body empty so contents
+/// can be added later.
+pub fn def<'c, 'a, B>(
+    builder: &B,
     location: Location<'c>,
     name: &str,
-    region_ops: I,
-) -> Result<StructDefOp<'c>, Error>
+    fill: impl FnOnce(&B) -> Result<(), Error>,
+) -> Result<StructDefOpRef<'c, 'a>, Error>
 where
-    I: IntoIterator<Item = Result<Operation<'c>, Error>>,
+    B: OpBuilderLike<'c>,
 {
     let ctx = location.context();
-    let region = Region::new();
-    let block = Block::new(&[]);
-    region_ops
-        .into_iter()
-        .try_for_each(|op| -> Result<(), Error> {
-            block.append_operation(op?);
-            Ok(())
-        })?;
-    region.append_block(block);
-    let name: Attribute = StringAttribute::new(unsafe { ctx.to_ref() }, name).into();
-    let attrs = [(ident!(ctx, "sym_name"), name)];
-
-    OperationBuilder::new("struct.def", location)
-        .add_attributes(&attrs)
-        .add_regions([region])
-        .build()
-        .map_err(Into::into)
-        .and_then(TryInto::try_into)
+    let op = unsafe {
+        OperationRef::from_raw(llzkStruct_StructDefOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            Identifier::new(ctx.to_ref(), name).to_raw(),
+        ))
+    };
+    let op: StructDefOpRef<'c, 'a> = op.try_into()?;
+    let region = op.body_region();
+    let block = match region.first_block() {
+        Some(block) => block,
+        None => region.append_block(Block::new(&[])),
+    };
+    let saved = builder.save_insertion_point();
+    builder.set_insertion_point_at_start(block);
+    let res = fill(builder);
+    builder.restore_insertion_point(saved);
+    res.map(|_| op)
 }
 
 /// Return `true` iff the given op is `struct.def`.
@@ -422,35 +429,33 @@ pub fn is_struct_def<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates a 'struct.member' op
-pub fn member<'c, T>(
+pub fn member<'c, 'a, T>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     name: &str,
     r#type: T,
     is_signal: bool,
     is_column: bool,
     is_public: bool,
-) -> Result<MemberDefOp<'c>, Error>
+) -> Result<MemberDefOpRef<'c, 'a>, Error>
 where
     T: Into<Type<'c>>,
 {
-    let ctx = location.context();
-    let r#type = TypeAttribute::new(r#type.into());
-    OperationBuilder::new("struct.member", location)
-        .add_attributes(&[
-            (
-                ident!(ctx, "sym_name"),
-                StringAttribute::new(unsafe { ctx.to_ref() }, name).into(),
-            ),
-            (ident!(ctx, "type"), r#type.into()),
-        ])
-        .build()
-        .map_err(Into::into)
-        .and_then(TryInto::try_into)
-        .inspect(|op: &MemberDefOp<'c>| {
-            op.set_signal(is_signal);
-            op.set_column(is_column);
-            op.set_public_attr(is_public);
-        })
+    let r#type = r#type.into();
+    unsafe {
+        OperationRef::from_raw(llzkStruct_MemberDefOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            StringRef::new(name).to_raw(),
+            r#type.to_raw(),
+            is_signal,
+            is_column,
+        ))
+    }
+    .try_into()
+    .inspect(|op: &MemberDefOpRef<'c, 'a>| {
+        op.set_public_attr(is_public);
+    })
 }
 
 /// Return `true` iff the given op is `struct.member`.
@@ -483,11 +488,30 @@ pub fn readm<'c, 'a>(
     }
 }
 
-/// Creates a 'struct.readm' op.
-///
-/// This factory method is not implemented yet.
-pub fn readm_with_offset<'c>() -> Operation<'c> {
-    todo!()
+/// Creates a 'struct.readm' op with an offset table access. This is only valid if the member is marked as a column.
+pub fn readm_with_offset<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    result_type: Type<'c>,
+    component: Value<'c, '_>,
+    member_name: &str,
+    distance: i64,
+) -> Result<OperationRef<'c, 'a>, Error> {
+    unsafe {
+        let raw = llzkStruct_MemberReadOpBuildWithLiteralDistance(
+            builder.to_raw(),
+            location.to_raw(),
+            result_type.to_raw(),
+            component.to_raw(),
+            Identifier::new(result_type.context().to_ref(), member_name).to_raw(),
+            distance,
+        );
+        if raw.ptr.is_null() {
+            Err(Error::BuildMethodFailed("readm_with_offset"))
+        } else {
+            Ok(OperationRef::from_raw(raw))
+        }
+    }
 }
 
 /// Return `true` iff the given op is `struct.readm`.
@@ -497,20 +521,24 @@ pub fn is_struct_readm<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates a 'struct.writem' op.
-pub fn writem<'c>(
+pub fn writem<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     component: Value<'c, '_>,
     member_name: &str,
     value: Value<'c, '_>,
-) -> Result<Operation<'c>, Error> {
+) -> Result<OperationRef<'c, 'a>, Error> {
     let context = location.context();
     let member_name = FlatSymbolRefAttribute::new(unsafe { context.to_ref() }, member_name);
-    let attrs = [(ident!(context, "member_name"), member_name.into())];
-    OperationBuilder::new("struct.writem", location)
-        .add_operands(&[component, value])
-        .add_attributes(&attrs)
-        .build()
-        .map_err(Into::into)
+    Ok(unsafe {
+        OperationRef::from_raw(llzkStruct_MemberWriteOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            component.to_raw(),
+            value.to_raw(),
+            member_name.to_raw(),
+        ))
+    })
 }
 
 /// Return `true` iff the given op is `struct.writem`.
@@ -520,11 +548,18 @@ pub fn is_struct_writem<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>) -> bool {
 }
 
 /// Creates a 'struct.new' op
-pub fn new<'c>(location: Location<'c>, r#type: StructType<'c>) -> Operation<'c> {
-    OperationBuilder::new("struct.new", location)
-        .add_results(&[r#type.into()])
-        .build()
-        .expect("valid operation")
+pub fn new<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+    r#type: StructType<'c>,
+) -> OperationRef<'c, 'a> {
+    unsafe {
+        OperationRef::from_raw(llzkStruct_CreateStructOpBuild(
+            builder.to_raw(),
+            location.to_raw(),
+            r#type.to_raw(),
+        ))
+    }
 }
 
 /// Return `true` iff the given op is `struct.new`.

--- a/llzk/src/dialect/verif/ops.rs
+++ b/llzk/src/dialect/verif/ops.rs
@@ -837,15 +837,12 @@ impl<'a, 'c: 'a> InvariantOpLike<'c, 'a> for InvariantOpRefMut<'c, 'a> {}
 impl<'a, 'c: 'a> InvariantOpMutLike<'c, 'a> for InvariantOpRefMut<'c, 'a> {}
 
 /// Creates a new invariant operation.
-pub fn invariant<'c, 'o, B>(
-    builder: &B,
+pub fn invariant<'c, 'o>(
+    builder: &impl OpBuilderLike<'c>,
     location: Location<'c>,
     loop_label: &str,
     args: &[(Type<'c>, Location<'c>)],
-) -> InvariantOpRef<'c, 'o>
-where
-    B: OpBuilderLike<'c>,
-{
+) -> InvariantOpRef<'c, 'o> {
     let (types, locations): (Vec<_>, Vec<_>) =
         args.iter().map(|(t, l)| (t.to_raw(), l.to_raw())).unzip();
     unsafe {
@@ -924,10 +921,10 @@ isa_fn!(verif, decreases);
 ///
 /// The operation is constructed as is and the caller is
 /// responsible of manually adding the body.
-pub fn step<'c, 'a, B>(builder: &B, location: Location<'c>) -> OperationRef<'c, 'a>
-where
-    B: OpBuilderLike<'c>,
-{
+pub fn step<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    location: Location<'c>,
+) -> OperationRef<'c, 'a> {
     unsafe { OperationRef::from_raw(llzkVerif_StepOpBuild(builder.to_raw(), location.to_raw())) }
 }
 

--- a/llzk/src/dialect/verif/ops.rs
+++ b/llzk/src/dialect/verif/ops.rs
@@ -872,13 +872,12 @@ where
 {
     let op = invariant(builder, location, loop_label, args);
     let body = op.body();
-    let saved = builder.save_insertion_point();
+
+    let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_end(body);
     let arguments =
         Vec::from_iter((0..body.argument_count()).map(|n| Value::from(body.argument(n).unwrap())));
-    let res = build(builder, &arguments);
-    builder.restore_insertion_point(saved);
-    res.map(|_| op)
+    build(builder, &arguments).map(|_| op)
 }
 
 isa_fn!(verif, invariant);
@@ -944,13 +943,13 @@ where
     let op = step(builder, location);
     let region = unsafe { RegionRef::from_raw(llzkVerif_StepOpGetRegion(op.to_raw())) };
     let block = region.append_block(Block::new(&[]));
-    let saved = builder.save_insertion_point();
+
+    let _guard = builder.insertion_guard();
     builder.set_insertion_point_at_end(block);
     let res = build(builder);
     if let Ok(value) = &res {
         step_yield(builder, location, *value);
     }
-    builder.restore_insertion_point(saved);
     res.map(|_| op)
 }
 

--- a/llzk/src/macros.rs
+++ b/llzk/src/macros.rs
@@ -374,3 +374,97 @@ macro_rules! isa_fn {
 }
 
 pub(crate) use isa_fn;
+
+macro_rules! dialect_op {
+    ($arity:ident $type_mode:ident $dialect:ident, $name:ident) => {
+        paste::paste! {
+            $crate::macros::dialect_op!(
+                $arity $type_mode $dialect,
+                $name,
+                [<llzk $dialect:camel _ $name:camel $dialect:camel OpBuild>]
+            );
+        }
+    };
+    (binop untyped $dialect:ident, $name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `", stringify!($dialect), ".", stringify!($name) ,"` operation.")]
+        pub fn $name<'c, 'a>(
+            builder: &impl $crate::builder::OpBuilderLike<'c>,
+            location: ::melior::ir::Location<'c>,
+            lhs: ::melior::ir::Value<'c, '_>,
+            rhs: ::melior::ir::Value<'c, '_>,
+        ) -> Result<::melior::ir::OperationRef<'c, 'a>, $crate::error::Error> {
+            Ok(unsafe {
+                ::melior::ir::OperationRef::from_raw($build(
+                    builder.to_raw(),
+                    location.to_raw(),
+                    ::melior::ir::ValueLike::to_raw(&lhs),
+                    ::melior::ir::ValueLike::to_raw(&rhs),
+                ))
+            })
+        }
+
+        $crate::macros::isa_fn!(prefixed $dialect, $name);
+    };
+    (binop typed $dialect:ident, $name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `", stringify!($dialect), ".", stringify!($name) ,"` operation.")]
+        pub fn $name<'c, 'a>(
+            builder: &impl $crate::builder::OpBuilderLike<'c>,
+            location: ::melior::ir::Location<'c>,
+            lhs: ::melior::ir::Value<'c, '_>,
+            rhs: ::melior::ir::Value<'c, '_>,
+        ) -> Result<::melior::ir::OperationRef<'c, 'a>, $crate::error::Error> {
+            let result = ::melior::ir::ValueLike::r#type(&lhs);
+            Ok(unsafe {
+                ::melior::ir::OperationRef::from_raw($build(
+                    builder.to_raw(),
+                    location.to_raw(),
+                    ::melior::ir::TypeLike::to_raw(&result),
+                    ::melior::ir::ValueLike::to_raw(&lhs),
+                    ::melior::ir::ValueLike::to_raw(&rhs),
+                ))
+            })
+        }
+
+        $crate::macros::isa_fn!(prefixed $dialect, $name);
+    };
+    (unop untyped $dialect:ident, $name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `", stringify!($dialect), ".", stringify!($name) ,"` operation.")]
+        pub fn $name<'c, 'a>(
+            builder: &impl $crate::builder::OpBuilderLike<'c>,
+            location: ::melior::ir::Location<'c>,
+            value: ::melior::ir::Value<'c, '_>,
+        ) -> Result<::melior::ir::OperationRef<'c, 'a>, $crate::error::Error> {
+            Ok(unsafe {
+                ::melior::ir::OperationRef::from_raw($build(
+                    builder.to_raw(),
+                    location.to_raw(),
+                    ::melior::ir::ValueLike::to_raw(&value),
+                ))
+            })
+        }
+
+        $crate::macros::isa_fn!(prefixed $dialect, $name);
+    };
+    (unop typed $dialect:ident, $name:ident, $build:ident) => {
+        #[doc = concat!("Creates a `", stringify!($dialect), ".", stringify!($name) ,"` operation.")]
+        pub fn $name<'c, 'a>(
+            builder: &impl $crate::builder::OpBuilderLike<'c>,
+            location: ::melior::ir::Location<'c>,
+            value: ::melior::ir::Value<'c, '_>,
+        ) -> Result<::melior::ir::OperationRef<'c, 'a>, $crate::error::Error> {
+            let result = ::melior::ir::ValueLike::r#type(&value);
+            Ok(unsafe {
+                ::melior::ir::OperationRef::from_raw($build(
+                    builder.to_raw(),
+                    location.to_raw(),
+                    ::melior::ir::TypeLike::to_raw(&result),
+                    ::melior::ir::ValueLike::to_raw(&value),
+                ))
+            })
+        }
+
+        $crate::macros::isa_fn!(prefixed $dialect, $name);
+    };
+}
+
+pub(crate) use dialect_op;

--- a/llzk/src/operation.rs
+++ b/llzk/src/operation.rs
@@ -138,6 +138,14 @@ pub fn erase_op<'c: 'a, 'a>(op: impl OperationLike<'c, 'a>) {
     }
 }
 
+/// Detach the given operation from its parent block, then erase it.
+#[inline]
+pub fn detach_and_erase_op<'c: 'a, 'a>(op: impl OperationLike<'c, 'a>) {
+    let mut op = unsafe { OperationRefMut::from_raw(op.to_raw()) };
+    op.remove_from_parent();
+    erase_op(op);
+}
+
 /// Return `true` iff the given op is has the given name.
 #[inline]
 pub fn isa<'c: 'a, 'a>(op: &impl OperationLike<'c, 'a>, name: &str) -> bool {

--- a/llzk/src/typing.rs
+++ b/llzk/src/typing.rs
@@ -1,9 +1,8 @@
 //! Utilities related to type unification.
 
-use std::ptr::null;
-
 use melior::{StringRef, ir::TypeLike};
 use mlir_sys::MlirStringRef;
+use std::ptr::null;
 
 /// Return `true` iff the two types are equivalent or could be equivalent after full
 /// instantiation of struct parameters.

--- a/llzk/tests/array_dialect.rs
+++ b/llzk/tests/array_dialect.rs
@@ -119,7 +119,9 @@ fn array_len() {
     let op = dialect::array::new(&builder, unknown, ty, ArrayCtor::Values(&[]));
     assert_eq!(1, op.result_count(), "op {op} must only have one result");
     let arr_ref = op.result(0).unwrap();
-    let arr_dim_op = arith::constant(&ctx, IntegerAttribute::new(index_ty, 0).into(), unknown);
+    let arr_dim_op = builder.insert(unknown, |ctx, loc| {
+        arith::constant(ctx, IntegerAttribute::new(index_ty, 0).into(), loc)
+    });
     assert_eq!(
         1,
         arr_dim_op.result_count(),

--- a/llzk/tests/array_dialect.rs
+++ b/llzk/tests/array_dialect.rs
@@ -2,7 +2,7 @@
 //! Integration tests for the array dialect.
 
 use llzk::{
-    builder::OpBuilder,
+    builder::{OpBuilder, OpBuilderLike as _},
     dialect::array::ArrayCtor,
     prelude::melior_dialects::arith,
     prelude::*,
@@ -18,7 +18,9 @@ fn array_new_empty() {
     let location = Location::unknown(&context);
     let module = llzk_module(location, None);
     let index_type = Type::index(&context);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         location,
         "array_new",
         FunctionType::new(&context, &[], &[]),
@@ -27,18 +29,17 @@ fn array_new_empty() {
     )
     .unwrap();
     {
-        let block = Block::new(&[]);
-        let builder = OpBuilder::at_block_begin(&context, &block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[]));
+        builder.set_insertion_point_at_start(block);
         let array_type = ArrayType::new(index_type, &[IntegerAttribute::new(index_type, 2).into()]);
         let _array = dialect::array::new(&builder, location, array_type, ArrayCtor::Empty);
-        block.append_operation(dialect::function::r#return(location, &[]));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        dialect::function::r#return(&builder, location, &[]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -58,7 +59,9 @@ fn array_new_affine_map() {
     let location = Location::unknown(&context);
     let module = llzk_module(location, None);
     let index_type = Type::index(&context);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         location,
         "array_new",
         FunctionType::new(&context, &[index_type, index_type], &[]),
@@ -68,10 +71,13 @@ fn array_new_affine_map() {
     .unwrap();
     {
         let block_arg = (index_type, location);
-        let block = Block::new(&[block_arg, block_arg]);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[block_arg, block_arg]));
         let arg0: Value = block.argument(0).unwrap().into();
         let arg1: Value = block.argument(1).unwrap().into();
-        let builder = OpBuilder::at_block_begin(&context, &block);
+        builder.set_insertion_point_at_start(block);
         let affine_map = Attribute::parse(&context, "affine_map<()[s0, s1] -> (s0 + s1)>")
             .expect("failed to parse affine_map");
         let array_type = ArrayType::new(index_type, &[affine_map]);
@@ -83,14 +89,10 @@ fn array_new_affine_map() {
             array_type,
             ArrayCtor::MapDimSlice(&[value_range], &[0]),
         );
-        block.append_operation(dialect::function::r#return(location, &[]));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        dialect::function::r#return(&builder, location, &[]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -124,7 +126,7 @@ fn array_len() {
         "op {arr_dim_op} must only have one result"
     );
     let arr_dim = arr_dim_op.result(0).unwrap();
-    let len = dialect::array::len(unknown, arr_ref.into(), arr_dim.into());
+    let len = dialect::array::len(&builder, unknown, arr_ref.into(), arr_dim.into());
     assert!(len.verify(), "op {len} failed to verify");
     assert!(dialect::array::is_array_len(&len));
 }

--- a/llzk/tests/array_dialect.rs
+++ b/llzk/tests/array_dialect.rs
@@ -26,13 +26,15 @@ fn array_new_empty() {
         FunctionType::new(&context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let array_type = ArrayType::new(index_type, &[IntegerAttribute::new(index_type, 2).into()]);
         let _array = dialect::array::new(&builder, location, array_type, ArrayCtor::Empty);
@@ -67,14 +69,15 @@ fn array_new_affine_map() {
         FunctionType::new(&context, &[index_type, index_type], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
-        let block_arg = (index_type, location);
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[block_arg, block_arg]));
+            .first_block()
+            .expect("function.def must have entry block");
         let arg0: Value = block.argument(0).unwrap().into();
         let arg1: Value = block.argument(1).unwrap().into();
         builder.set_insertion_point_at_start(block);

--- a/llzk/tests/bool_dialect.rs
+++ b/llzk/tests/bool_dialect.rs
@@ -23,6 +23,7 @@ fn f_eq() {
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_witness_attr(true);
@@ -30,7 +31,8 @@ fn f_eq() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::bool::eq(
             &builder,
@@ -69,6 +71,7 @@ fn f_ne() {
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_witness_attr(true);
@@ -76,7 +79,8 @@ fn f_ne() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::bool::ne(
             &builder,
@@ -115,6 +119,7 @@ fn f_lt() {
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_witness_attr(true);
@@ -122,7 +127,8 @@ fn f_lt() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::bool::lt(
             &builder,
@@ -161,6 +167,7 @@ fn f_le() {
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_witness_attr(true);
@@ -168,7 +175,8 @@ fn f_le() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::bool::le(
             &builder,
@@ -207,6 +215,7 @@ fn f_gt() {
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_witness_attr(true);
@@ -214,7 +223,8 @@ fn f_gt() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::bool::gt(
             &builder,
@@ -253,6 +263,7 @@ fn f_ge() {
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_witness_attr(true);
@@ -260,7 +271,8 @@ fn f_ge() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::bool::ge(
             &builder,

--- a/llzk/tests/bool_dialect.rs
+++ b/llzk/tests/bool_dialect.rs
@@ -291,7 +291,9 @@ fn f_assert() {
     let module = Module::new(loc);
     let builder = OpBuilder::at_block_begin(&context, module.body());
 
-    let cond = arith::constant(&context, BoolAttribute::new(&context, false).into(), loc);
+    let cond = builder.insert(loc, |ctx, loc| {
+        arith::constant(ctx, BoolAttribute::new(ctx, false).into(), loc)
+    });
     let cond = cond.result(0).unwrap().into();
     let op = llzk::dialect::bool::assert(&builder, loc, cond, Some("assertion failed"))
         .expect("failed to build assert op");

--- a/llzk/tests/bool_dialect.rs
+++ b/llzk/tests/bool_dialect.rs
@@ -1,6 +1,7 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for the bool dialect.
 
+use llzk::builder::{OpBuilder, OpBuilderLike as _};
 use llzk::prelude::*;
 use melior::dialect::arith;
 
@@ -14,7 +15,9 @@ fn f_eq() {
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
     let bool_type: Type = IntegerType::new(&context, 1).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_eq",
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
@@ -24,26 +27,22 @@ fn f_eq() {
     .unwrap();
     f.set_allow_witness_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::bool::eq(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::bool::eq(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -62,7 +61,9 @@ fn f_ne() {
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
     let bool_type: Type = IntegerType::new(&context, 1).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_ne",
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
@@ -72,26 +73,22 @@ fn f_ne() {
     .unwrap();
     f.set_allow_witness_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::bool::ne(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::bool::ne(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -110,7 +107,9 @@ fn f_lt() {
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
     let bool_type: Type = IntegerType::new(&context, 1).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_lt",
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
@@ -120,26 +119,22 @@ fn f_lt() {
     .unwrap();
     f.set_allow_witness_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::bool::lt(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::bool::lt(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -158,7 +153,9 @@ fn f_le() {
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
     let bool_type: Type = IntegerType::new(&context, 1).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_le",
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
@@ -168,26 +165,22 @@ fn f_le() {
     .unwrap();
     f.set_allow_witness_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::bool::le(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::bool::le(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -206,7 +199,9 @@ fn f_gt() {
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
     let bool_type: Type = IntegerType::new(&context, 1).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_gt",
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
@@ -216,26 +211,22 @@ fn f_gt() {
     .unwrap();
     f.set_allow_witness_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::bool::gt(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::bool::gt(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -254,7 +245,9 @@ fn f_ge() {
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
     let bool_type: Type = IntegerType::new(&context, 1).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_ge",
         FunctionType::new(&context, &[felt_type, felt_type], &[bool_type]),
@@ -264,26 +257,22 @@ fn f_ge() {
     .unwrap();
     f.set_allow_witness_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::bool::ge(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::bool::ge(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -299,10 +288,12 @@ fn f_assert() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
 
     let cond = arith::constant(&context, BoolAttribute::new(&context, false).into(), loc);
     let cond = cond.result(0).unwrap().into();
-    let op = llzk::dialect::bool::assert(loc, cond, Some("assertion failed"))
+    let op = llzk::dialect::bool::assert(&builder, loc, cond, Some("assertion failed"))
         .expect("failed to build assert op");
 
     assert!(op.verify());

--- a/llzk/tests/cast_dialect.rs
+++ b/llzk/tests/cast_dialect.rs
@@ -1,6 +1,7 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for the cast dialect.
 
+use llzk::builder::OpBuilder;
 use llzk::dialect::cast::*;
 use llzk::prelude::melior_dialects::arith;
 use llzk::prelude::*;
@@ -12,13 +13,15 @@ fn tofelt_unspecified() {
     common::setup();
     let ctx = LlzkContext::new();
     let loc = Location::unknown(&ctx);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&ctx, module.body());
     let index_ty = Type::index(&ctx);
 
     let c = arith::constant(&ctx, IntegerAttribute::new(index_ty, 0).into(), loc);
-    let a = tofelt(loc, c.result(0).unwrap().into(), None);
+    let a = tofelt(&builder, loc, c.result(0).unwrap().into(), None);
 
     let ir = format!("{a}");
-    let expected = "%0 = cast.tofelt <<UNKNOWN SSA VALUE>> : index, !felt.type\n";
+    let expected = "%0 = \"cast.tofelt\"(<<UNKNOWN SSA VALUE>>) <{overflow = #cast<overflow assert>}> : (index) -> !felt.type";
     assert_eq!(ir, expected);
 }
 
@@ -27,13 +30,43 @@ fn tofelt_specified() {
     common::setup();
     let ctx = LlzkContext::new();
     let loc = Location::unknown(&ctx);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&ctx, module.body());
     let index_ty = Type::index(&ctx);
     let felt_ty = FeltType::with_field(&ctx, "babybear");
 
     let c = arith::constant(&ctx, IntegerAttribute::new(index_ty, 0).into(), loc);
-    let a = tofelt(loc, c.result(0).unwrap().into(), Some(felt_ty));
+    let a = tofelt(&builder, loc, c.result(0).unwrap().into(), Some(felt_ty));
 
     let ir = format!("{a}");
-    let expected = "%0 = cast.tofelt <<UNKNOWN SSA VALUE>> : index, !felt.type<\"babybear\">\n";
+    let expected = "%0 = \"cast.tofelt\"(<<UNKNOWN SSA VALUE>>) <{overflow = #cast<overflow assert>}> : (index) -> !felt.type<\"babybear\">";
     assert_eq!(ir, expected);
+}
+
+#[test]
+fn toindex_unspecified_overflow() {
+    common::setup();
+    let ctx = LlzkContext::new();
+    let loc = Location::unknown(&ctx);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&ctx, module.body());
+
+    let felt = dialect::felt::constant(&builder, loc, FeltConstAttribute::new(&ctx, 0, None))
+        .expect("valid felt const");
+    let index = toindex(&builder, loc, felt.result(0).unwrap().into(), None);
+
+    assert!(index.verify());
+    assert!(!format!("{index}").contains("overflow"));
+}
+
+#[test]
+fn overflow_semantics_attr_round_trip() {
+    common::setup();
+    let ctx = LlzkContext::new();
+    let attr = OverflowSemanticsAttribute::new(&ctx, OverflowSemantics::Wrap);
+
+    assert_eq!(attr.value(), OverflowSemantics::Wrap);
+    let attr: Attribute = attr.into();
+    let attr = OverflowSemanticsAttribute::try_from(attr).unwrap();
+    assert_eq!(attr.value(), OverflowSemantics::Wrap);
 }

--- a/llzk/tests/cast_dialect.rs
+++ b/llzk/tests/cast_dialect.rs
@@ -1,7 +1,7 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for the cast dialect.
 
-use llzk::builder::OpBuilder;
+use llzk::builder::{OpBuilder, OpBuilderLike as _};
 use llzk::dialect::cast::*;
 use llzk::prelude::melior_dialects::arith;
 use llzk::prelude::*;
@@ -17,11 +17,13 @@ fn tofelt_unspecified() {
     let builder = OpBuilder::at_block_begin(&ctx, module.body());
     let index_ty = Type::index(&ctx);
 
-    let c = arith::constant(&ctx, IntegerAttribute::new(index_ty, 0).into(), loc);
+    let c = builder.insert(loc, |ctx, loc| {
+        arith::constant(ctx, IntegerAttribute::new(index_ty, 0).into(), loc)
+    });
     let a = tofelt(&builder, loc, c.result(0).unwrap().into(), None);
 
     let ir = format!("{a}");
-    let expected = "%0 = \"cast.tofelt\"(<<UNKNOWN SSA VALUE>>) <{overflow = #cast<overflow assert>}> : (index) -> !felt.type";
+    let expected = "%0 = cast.tofelt %c0 : index, !felt.type";
     assert_eq!(ir, expected);
 }
 
@@ -35,11 +37,13 @@ fn tofelt_specified() {
     let index_ty = Type::index(&ctx);
     let felt_ty = FeltType::with_field(&ctx, "babybear");
 
-    let c = arith::constant(&ctx, IntegerAttribute::new(index_ty, 0).into(), loc);
+    let c = builder.insert(loc, |ctx, loc| {
+        arith::constant(ctx, IntegerAttribute::new(index_ty, 0).into(), loc)
+    });
     let a = tofelt(&builder, loc, c.result(0).unwrap().into(), Some(felt_ty));
 
     let ir = format!("{a}");
-    let expected = "%0 = \"cast.tofelt\"(<<UNKNOWN SSA VALUE>>) <{overflow = #cast<overflow assert>}> : (index) -> !felt.type<\"babybear\">";
+    let expected = "%0 = cast.tofelt %c0 : index, !felt.type<\"babybear\">";
     assert_eq!(ir, expected);
 }
 

--- a/llzk/tests/felt_dialect.rs
+++ b/llzk/tests/felt_dialect.rs
@@ -1,6 +1,7 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for the felt dialect.
 
+use llzk::builder::{OpBuilder, OpBuilderLike as _};
 use llzk::prelude::*;
 
 mod common;
@@ -11,7 +12,9 @@ fn f_constant() {
     let context = LlzkContext::new();
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_constant",
         FunctionType::new(&context, &[], &[FeltType::new(&context).into()]),
@@ -20,21 +23,18 @@ fn f_constant() {
     )
     .unwrap();
     {
-        let block = Block::new(&[]);
-        let felt = block.append_operation(
-            dialect::felt::constant(loc, FeltConstAttribute::new(&context, 42, None)).unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
-            loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[]));
+        builder.set_insertion_point_at_start(block);
+        let felt =
+            dialect::felt::constant(&builder, loc, FeltConstAttribute::new(&context, 42, None))
+                .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -52,7 +52,9 @@ fn f_add() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_add",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -61,26 +63,22 @@ fn f_add() {
     )
     .unwrap();
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::add(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::add(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -98,7 +96,9 @@ fn f_sub() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_sub",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -107,26 +107,22 @@ fn f_sub() {
     )
     .unwrap();
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::sub(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::sub(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -144,7 +140,9 @@ fn f_mul() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_mul",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -153,26 +151,22 @@ fn f_mul() {
     )
     .unwrap();
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::mul(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::mul(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -190,7 +184,9 @@ fn f_div() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_div",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -199,26 +195,22 @@ fn f_div() {
     )
     .unwrap();
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::div(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::div(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -236,7 +228,9 @@ fn f_uintdiv() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_uintdiv",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -246,26 +240,22 @@ fn f_uintdiv() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::uintdiv(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::uintdiv(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -283,7 +273,9 @@ fn f_sintdiv() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_sintdiv",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -293,26 +285,22 @@ fn f_sintdiv() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::sintdiv(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::sintdiv(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -330,7 +318,9 @@ fn f_umod() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_umod",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -340,26 +330,22 @@ fn f_umod() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::umod(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::umod(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -377,7 +363,9 @@ fn f_smod() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_smod",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -387,26 +375,22 @@ fn f_smod() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::smod(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::smod(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -424,7 +408,9 @@ fn f_neg() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_neg",
         FunctionType::new(&context, &[felt_type], &[felt_type]),
@@ -433,20 +419,16 @@ fn f_neg() {
     )
     .unwrap();
     {
-        let block = Block::new(&[(felt_type, loc)]);
-        let felt = block
-            .append_operation(dialect::felt::neg(loc, block.argument(0).unwrap().into()).unwrap());
-        block.append_operation(dialect::function::r#return(
-            loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::neg(&builder, loc, block.argument(0).unwrap().into()).unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -464,7 +446,9 @@ fn f_inv() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_inv",
         FunctionType::new(&context, &[felt_type], &[felt_type]),
@@ -474,20 +458,16 @@ fn f_inv() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc)]);
-        let felt = block
-            .append_operation(dialect::felt::inv(loc, block.argument(0).unwrap().into()).unwrap());
-        block.append_operation(dialect::function::r#return(
-            loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::inv(&builder, loc, block.argument(0).unwrap().into()).unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -505,7 +485,9 @@ fn f_bit_not() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_bit_not",
         FunctionType::new(&context, &[felt_type], &[felt_type]),
@@ -515,21 +497,17 @@ fn f_bit_not() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::bit_not(loc, block.argument(0).unwrap().into()).unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
-            loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt =
+            dialect::felt::bit_not(&builder, loc, block.argument(0).unwrap().into()).unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -547,7 +525,9 @@ fn f_shl() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_shl",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -557,26 +537,22 @@ fn f_shl() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::shl(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::shl(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -594,7 +570,9 @@ fn f_shr() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_shr",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -604,26 +582,22 @@ fn f_shr() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::shr(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::shr(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -641,7 +615,9 @@ fn f_bit_and() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_bit_and",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -651,26 +627,22 @@ fn f_bit_and() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::bit_and(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::bit_and(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -688,7 +660,9 @@ fn f_bit_or() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_bit_or",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -698,26 +672,22 @@ fn f_bit_or() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::bit_or(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::bit_or(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -735,7 +705,9 @@ fn f_bit_xor() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "f_bit_xor",
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
@@ -745,26 +717,22 @@ fn f_bit_xor() {
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
     {
-        let block = Block::new(&[(felt_type, loc), (felt_type, loc)]);
-        let felt = block.append_operation(
-            dialect::felt::bit_xor(
-                loc,
-                block.argument(0).unwrap().into(),
-                block.argument(1).unwrap().into(),
-            )
-            .unwrap(),
-        );
-        block.append_operation(dialect::function::r#return(
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+        builder.set_insertion_point_at_start(block);
+        let felt = dialect::felt::bit_xor(
+            &builder,
             loc,
-            &[felt.result(0).unwrap().into()],
-        ));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+            block.argument(0).unwrap().into(),
+            block.argument(1).unwrap().into(),
+        )
+        .unwrap();
+        dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");

--- a/llzk/tests/felt_dialect.rs
+++ b/llzk/tests/felt_dialect.rs
@@ -20,13 +20,15 @@ fn f_constant() {
         FunctionType::new(&context, &[], &[FeltType::new(&context).into()]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt =
             dialect::felt::constant(&builder, loc, FeltConstAttribute::new(&context, 42, None))
@@ -60,13 +62,15 @@ fn f_add() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::add(
             &builder,
@@ -104,13 +108,15 @@ fn f_sub() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::sub(
             &builder,
@@ -148,13 +154,15 @@ fn f_mul() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::mul(
             &builder,
@@ -192,13 +200,15 @@ fn f_div() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::div(
             &builder,
@@ -236,6 +246,7 @@ fn f_uintdiv() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -243,7 +254,8 @@ fn f_uintdiv() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::uintdiv(
             &builder,
@@ -281,6 +293,7 @@ fn f_sintdiv() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -288,7 +301,8 @@ fn f_sintdiv() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::sintdiv(
             &builder,
@@ -326,6 +340,7 @@ fn f_umod() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -333,7 +348,8 @@ fn f_umod() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::umod(
             &builder,
@@ -371,6 +387,7 @@ fn f_smod() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -378,7 +395,8 @@ fn f_smod() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::smod(
             &builder,
@@ -416,13 +434,15 @@ fn f_neg() {
         FunctionType::new(&context, &[felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::neg(&builder, loc, block.argument(0).unwrap().into()).unwrap();
         dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
@@ -454,6 +474,7 @@ fn f_inv() {
         FunctionType::new(&context, &[felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -461,7 +482,8 @@ fn f_inv() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::inv(&builder, loc, block.argument(0).unwrap().into()).unwrap();
         dialect::function::r#return(&builder, loc, &[felt.result(0).unwrap().into()]);
@@ -493,6 +515,7 @@ fn f_bit_not() {
         FunctionType::new(&context, &[felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -500,7 +523,8 @@ fn f_bit_not() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt =
             dialect::felt::bit_not(&builder, loc, block.argument(0).unwrap().into()).unwrap();
@@ -533,6 +557,7 @@ fn f_shl() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -540,7 +565,8 @@ fn f_shl() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::shl(
             &builder,
@@ -578,6 +604,7 @@ fn f_shr() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -585,7 +612,8 @@ fn f_shr() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::shr(
             &builder,
@@ -623,6 +651,7 @@ fn f_bit_and() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -630,7 +659,8 @@ fn f_bit_and() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::bit_and(
             &builder,
@@ -668,6 +698,7 @@ fn f_bit_or() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -675,7 +706,8 @@ fn f_bit_or() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::bit_or(
             &builder,
@@ -713,6 +745,7 @@ fn f_bit_xor() {
         FunctionType::new(&context, &[felt_type, felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     f.set_allow_non_native_field_ops_attr(true);
@@ -720,7 +753,8 @@ fn f_bit_xor() {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[(felt_type, loc), (felt_type, loc)]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         let felt = dialect::felt::bit_xor(
             &builder,

--- a/llzk/tests/function_dialect.rs
+++ b/llzk/tests/function_dialect.rs
@@ -26,13 +26,15 @@ fn empty_function() {
         FunctionType::new(&context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         dialect::function::r#return(&builder, loc, &[]);
     }
@@ -62,13 +64,15 @@ fn function_call() {
         FunctionType::new(&context, &[], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         // Build call to itself
         let name = FlatSymbolRefAttribute::new(&context, "recursive");
@@ -100,13 +104,15 @@ fn function_call_with_map_operands() {
         FunctionType::new(&context, &[], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
         let block = f
             .body()
             .expect("function.def must have body region")
-            .append_block(Block::new(&[]));
+            .first_block()
+            .expect("function.def must have entry block");
         builder.set_insertion_point_at_start(block);
         // Build call to itself
         let name = FlatSymbolRefAttribute::new(&context, "recursive");
@@ -303,6 +309,7 @@ fn func_def_op_get_function_type() {
         FunctionType::new(&context, &[felt_type], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     let result = op.function_type().unwrap();
@@ -325,6 +332,7 @@ fn func_def_op_set_function_type() {
         FunctionType::new(&context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     assert_eq!(op.function_type().unwrap().input_count(), 0);
@@ -346,6 +354,7 @@ fn func_def_op_get_sym_name() {
         FunctionType::new(&context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     assert_eq!(op.sym_name().unwrap().value(), "my_func");
@@ -365,6 +374,7 @@ fn func_def_op_set_sym_name() {
         FunctionType::new(&context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     assert_eq!(op.sym_name().unwrap().value(), "my_func");
@@ -386,16 +396,17 @@ fn func_def_op_is_declaration() {
         FunctionType::new(&context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
-    // A freshly created FuncDefOp has no body blocks — it is a declaration.
-    assert!(op.is_declaration());
+    // `empty_region` creates an entry block, so the op is no longer a declaration.
+    assert!(!op.is_declaration());
 
-    // After appending a block, it is no longer a declaration.
     let block = op
         .body()
         .expect("function.def must have body region")
-        .append_block(Block::new(&[]));
+        .first_block()
+        .expect("function.def must have entry block");
     builder.set_insertion_point_at_start(block);
     dialect::function::r#return(&builder, loc, &[]);
     assert!(!op.is_declaration());
@@ -415,16 +426,17 @@ fn func_def_op_get_body() {
         FunctionType::new(&context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
-    // A freshly created FuncDefOp already has a (empty) region; get_body returns Ok.
+    // A freshly created FuncDefOp already has an empty entry block.
     assert!(op.body().is_ok());
 
-    // After appending a block, get_body still succeeds.
     let block = op
         .body()
         .expect("function.def must have body region")
-        .append_block(Block::new(&[]));
+        .first_block()
+        .expect("function.def must have entry block");
     builder.set_insertion_point_at_start(block);
     dialect::function::r#return(&builder, loc, &[]);
     assert!(op.body().is_ok());
@@ -445,6 +457,7 @@ fn func_def_op_arg_name_round_trip() {
         FunctionType::new(&context, &[felt_type], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
 
@@ -471,6 +484,7 @@ fn func_def_op_res_name_round_trip() {
         FunctionType::new(&context, &[], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
 
@@ -501,10 +515,7 @@ fn func_def_op_def_with_signature_attrs_prints_named_arg_and_result() {
     )
     .unwrap();
 
-    let block = op
-        .body()
-        .unwrap()
-        .append_block(Block::new(&[(felt_type, loc)]));
+    let block = op.body().unwrap().first_block().unwrap();
     let arg: Value = block.argument(0).unwrap().into();
     builder.set_insertion_point_at_start(block);
     dialect::function::r#return(&builder, loc, &[arg]);
@@ -529,6 +540,7 @@ fn func_def_op_signature_name_accessors_return_out_of_bounds() {
         FunctionType::new(&context, &[felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
 
@@ -565,6 +577,7 @@ fn func_def_op_arg_and_res_attrs_round_trip() {
         FunctionType::new(&context, &[felt_type], &[felt_type]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
 

--- a/llzk/tests/function_dialect.rs
+++ b/llzk/tests/function_dialect.rs
@@ -2,7 +2,9 @@
 //! Integration tests for the function dialect.
 
 use llzk::{
-    attributes::array::ArrayAttribute, builder::OpBuilder, map_operands::MapOperandsBuilder,
+    attributes::array::ArrayAttribute,
+    builder::{OpBuilder, OpBuilderLike},
+    map_operands::MapOperandsBuilder,
     prelude::*,
 };
 use llzk_sys::{FUNCTION_ARG_NAME_ATTR_NAME, FUNCTION_RES_NAME_ATTR_NAME};
@@ -16,7 +18,9 @@ fn empty_function() {
     let context = LlzkContext::new();
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "empty",
         FunctionType::new(&context, &[], &[]),
@@ -25,15 +29,15 @@ fn empty_function() {
     )
     .unwrap();
     {
-        let block = Block::new(&[]);
-        block.append_operation(dialect::function::r#return(loc, &[]));
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[]));
+        builder.set_insertion_point_at_start(block);
+        dialect::function::r#return(&builder, loc, &[]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert!(f.verify());
     log::info!("Op passed verification");
     let ir = format!("{f}");
@@ -50,7 +54,9 @@ fn function_call() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "recursive",
         FunctionType::new(&context, &[], &[felt_type]),
@@ -59,8 +65,11 @@ fn function_call() {
     )
     .unwrap();
     {
-        let block = Block::new(&[]);
-        let builder = OpBuilder::at_block_begin(&context, &block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[]));
+        builder.set_insertion_point_at_start(block);
         // Build call to itself
         let name = FlatSymbolRefAttribute::new(&context, "recursive");
         let v = dialect::function::call(&builder, loc, name, &[], &[felt_type])
@@ -69,15 +78,10 @@ fn function_call() {
             .map(Value::from)
             .unwrap();
         // Build return operation
-        block.append_operation(dialect::function::r#return(loc, &[v]));
-        // Add Block to function
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        dialect::function::r#return(&builder, loc, &[v]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert_test!(f, module, @file "expected/function_call.mlir");
 }
 
@@ -88,7 +92,9 @@ fn function_call_with_map_operands() {
     let module = llzk_module(Location::unknown(&context), None);
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let f = dialect::function::def(
+        &builder,
         loc,
         "recursive",
         FunctionType::new(&context, &[], &[felt_type]),
@@ -97,8 +103,11 @@ fn function_call_with_map_operands() {
     )
     .unwrap();
     {
-        let block = Block::new(&[]);
-        let builder = OpBuilder::at_block_begin(&context, &block);
+        let block = f
+            .body()
+            .expect("function.def must have body region")
+            .append_block(Block::new(&[]));
+        builder.set_insertion_point_at_start(block);
         // Build call to itself
         let name = FlatSymbolRefAttribute::new(&context, "recursive");
         let map_operands = MapOperandsBuilder::new();
@@ -115,35 +124,38 @@ fn function_call_with_map_operands() {
         .map(Value::from)
         .unwrap();
         // Build return operation
-        block.append_operation(dialect::function::r#return(loc, &[v]));
-        // Add Block to function
-        f.region(0)
-            .expect("function.def must have at least 1 region")
-            .append_block(block);
+        dialect::function::r#return(&builder, loc, &[v]);
     }
 
     assert_eq!(f.region_count(), 1);
-    let f = module.body().append_operation(f.into());
     assert_test!(f, module, @file "expected/function_call.mlir");
 }
 
-fn make_empty_struct<'c>(context: &'c LlzkContext, name: &str) -> StructDefOp<'c> {
+fn make_empty_struct<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    context: &'c LlzkContext,
+    name: &str,
+) -> StructDefOpRef<'c, 'a> {
     let loc = Location::unknown(context);
     let typ = StructType::from_str(context, name);
-    dialect::r#struct::def(loc, name, {
-        [
-            dialect::r#struct::helpers::compute_fn(loc, typ, &[], None).map(Into::into),
-            dialect::r#struct::helpers::constrain_fn(loc, typ, &[], None).map(Into::into),
-        ]
+    dialect::r#struct::def(builder, loc, name, |builder| {
+        dialect::r#struct::helpers::compute_fn(builder, loc, typ, &[], None)?;
+        dialect::r#struct::helpers::constrain_fn(builder, loc, typ, &[], None)?;
+        Ok(())
     })
     .unwrap()
 }
 
-fn make_product_struct<'c>(context: &'c LlzkContext, name: &str) -> StructDefOp<'c> {
+fn make_product_struct<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    context: &'c LlzkContext,
+    name: &str,
+) -> StructDefOpRef<'c, 'a> {
     let loc = Location::unknown(context);
     let typ = StructType::from_str(context, name);
-    dialect::r#struct::def(loc, name, {
-        [dialect::r#struct::helpers::product_fn(loc, typ, &[], None).map(Into::into)]
+    dialect::r#struct::def(builder, loc, name, |builder| {
+        dialect::r#struct::helpers::product_fn(builder, loc, typ, &[], None)?;
+        Ok(())
     })
     .unwrap()
 }
@@ -155,8 +167,8 @@ fn func_def_op_self_value_of_compute() {
     let module = llzk_module(Location::unknown(&context), None);
     let module_body = module.body();
 
-    let s = make_empty_struct(&context, "StructA");
-    let s = StructDefOpRef::try_from(module_body.append_operation(s.into())).unwrap();
+    let builder = OpBuilder::at_block_begin(&context, module_body);
+    let s = make_empty_struct(&builder, &context, "StructA");
     llzk::operation::verify_operation_with_diags(&s).expect("verification failed");
     log::info!("Struct passed verification");
 
@@ -165,8 +177,8 @@ fn func_def_op_self_value_of_compute() {
     // Get the expected value. The first operation in the compute function is
     // the CreateStructOp, whose first result is the self value.
     let expected = compute_fn
-        .region(0)
-        .expect("failed to get first region")
+        .body()
+        .expect("failed to get body region")
         .first_block()
         .expect("failed to get first block")
         .first_operation()
@@ -184,8 +196,8 @@ fn func_def_op_self_value_of_constrain() {
     let module = llzk_module(Location::unknown(&context), None);
     let module_body = module.body();
 
-    let s = make_empty_struct(&context, "StructA");
-    let s = StructDefOpRef::try_from(module_body.append_operation(s.into())).unwrap();
+    let builder = OpBuilder::at_block_begin(&context, module_body);
+    let s = make_empty_struct(&builder, &context, "StructA");
     llzk::operation::verify_operation_with_diags(&s).expect("verification failed");
     log::info!("Struct passed verification");
 
@@ -208,25 +220,25 @@ fn call_op_self_value_of_compute() {
     let module = llzk_module(Location::unknown(&context), None);
     let module_body = module.body();
 
-    let s1 = make_empty_struct(&context, "StructA");
-    let s1 = StructDefOpRef::try_from(module_body.append_operation(s1.into())).unwrap();
+    let builder = OpBuilder::at_block_begin(&context, module_body);
+    let s1 = make_empty_struct(&builder, &context, "StructA");
     assert!(s1.verify());
     log::info!("Struct 1 passed verification");
 
-    let s2 = make_empty_struct(&context, "StructB");
-    let s2 = StructDefOpRef::try_from(module_body.append_operation(s2.into())).unwrap();
+    builder.set_insertion_point_at_end(module_body);
+    let s2 = make_empty_struct(&builder, &context, "StructB");
     assert!(s2.verify());
     log::info!("Struct 2 passed verification");
 
     let s2_compute_body = s2
         .compute_func()
         .expect("failed to get compute function")
-        .region(0)
-        .expect("failed to get first region")
+        .body()
+        .expect("failed to get body region")
         .first_block()
         .expect("failed to get first block");
-    let builder = OpBuilder::at_block_end(&context, s2_compute_body);
     let loc = Location::unknown(&context);
+    builder.set_insertion_point(s2_compute_body.terminator().unwrap());
     let name = SymbolRefAttribute::new_from_str(&context, "StructA", &["compute"]);
     let call = dialect::function::call(&builder, loc, name, &[], &[s1.r#type()]).unwrap();
 
@@ -248,23 +260,23 @@ fn call_op_product_classifiers() {
     let module = llzk_module(Location::unknown(&context), None);
     let module_body = module.body();
 
-    let s1 = make_product_struct(&context, "StructProdA");
-    let s1 = StructDefOpRef::try_from(module_body.append_operation(s1.into())).unwrap();
+    let builder = OpBuilder::at_block_begin(&context, module_body);
+    let s1 = make_product_struct(&builder, &context, "StructProdA");
     assert!(s1.verify());
 
-    let s2 = make_product_struct(&context, "StructProdB");
-    let s2 = StructDefOpRef::try_from(module_body.append_operation(s2.into())).unwrap();
+    builder.set_insertion_point_at_end(module_body);
+    let s2 = make_product_struct(&builder, &context, "StructProdB");
     assert!(s2.verify());
 
     let product_body = s2
         .product_func()
         .expect("failed to get product function")
-        .region(0)
-        .expect("failed to get first region")
+        .body()
+        .expect("failed to get body region")
         .first_block()
         .expect("failed to get first block");
-    let builder = OpBuilder::at_block_end(&context, product_body);
     let loc = Location::unknown(&context);
+    builder.set_insertion_point(product_body.terminator().unwrap());
     let name = SymbolRefAttribute::new_from_str(&context, "StructProdA", &["product"]);
     let call = dialect::function::call(&builder, loc, name, &[], &[s1.r#type()]).unwrap();
 
@@ -272,53 +284,6 @@ fn call_op_product_classifiers() {
     assert!(call.callee_is_struct_product());
     assert!(!call.callee_is_compute());
     assert!(!call.callee_is_constrain());
-}
-
-#[test]
-fn func_def_op_ref_from_borrow_equals_original() {
-    common::setup();
-    let context = LlzkContext::new();
-    let loc = Location::unknown(&context);
-
-    let op = dialect::function::def(
-        loc,
-        "my_func",
-        FunctionType::new(&context, &[], &[]),
-        &[],
-        None,
-    )
-    .unwrap();
-
-    // Convert a shared borrow into a FuncDefOpRef
-    let op_ref = FuncDefOpRef::from(&op);
-
-    // The ref must point to the same underlying operation.
-    assert_eq!(op_ref, op);
-}
-
-#[test]
-fn func_def_op_ref_from_borrow_does_not_drop_original() {
-    common::setup();
-    let context = LlzkContext::new();
-    let loc = Location::unknown(&context);
-
-    let op = dialect::function::def(
-        loc,
-        "my_func",
-        FunctionType::new(&context, &[], &[]),
-        &[],
-        None,
-    )
-    .unwrap();
-
-    {
-        let op_ref = FuncDefOpRef::from(&op);
-        // Use the ref so it isn't optimized away.
-        assert_eq!(op_ref.region_count(), 1);
-    } // `op_ref` drops here — `op` must still be alive.
-
-    // `op` is still valid: its Drop will run mlirOperationDestroy exactly once.
-    assert_eq!(op.region_count(), 1);
 }
 
 // Tests for FuncDefOpLike methods added in e2157c6
@@ -329,7 +294,10 @@ fn func_def_op_get_function_type() {
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "my_func",
         FunctionType::new(&context, &[felt_type], &[]),
@@ -348,7 +316,10 @@ fn func_def_op_set_function_type() {
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "my_func",
         FunctionType::new(&context, &[], &[]),
@@ -366,7 +337,10 @@ fn func_def_op_get_sym_name() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "my_func",
         FunctionType::new(&context, &[], &[]),
@@ -382,7 +356,10 @@ fn func_def_op_set_sym_name() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "my_func",
         FunctionType::new(&context, &[], &[]),
@@ -400,7 +377,10 @@ fn func_def_op_is_declaration() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "my_func",
         FunctionType::new(&context, &[], &[]),
@@ -412,11 +392,12 @@ fn func_def_op_is_declaration() {
     assert!(op.is_declaration());
 
     // After appending a block, it is no longer a declaration.
-    let block = Block::new(&[]);
-    block.append_operation(dialect::function::r#return(loc, &[]));
-    op.region(0)
-        .expect("function.def must have at least 1 region")
-        .append_block(block);
+    let block = op
+        .body()
+        .expect("function.def must have body region")
+        .append_block(Block::new(&[]));
+    builder.set_insertion_point_at_start(block);
+    dialect::function::r#return(&builder, loc, &[]);
     assert!(!op.is_declaration());
 }
 
@@ -425,7 +406,10 @@ fn func_def_op_get_body() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "my_func",
         FunctionType::new(&context, &[], &[]),
@@ -437,11 +421,12 @@ fn func_def_op_get_body() {
     assert!(op.body().is_ok());
 
     // After appending a block, get_body still succeeds.
-    let block = Block::new(&[]);
-    block.append_operation(dialect::function::r#return(loc, &[]));
-    op.region(0)
-        .expect("function.def must have at least 1 region")
-        .append_block(block);
+    let block = op
+        .body()
+        .expect("function.def must have body region")
+        .append_block(Block::new(&[]));
+    builder.set_insertion_point_at_start(block);
+    dialect::function::r#return(&builder, loc, &[]);
     assert!(op.body().is_ok());
 }
 
@@ -451,7 +436,10 @@ fn func_def_op_arg_name_round_trip() {
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "named_arg",
         FunctionType::new(&context, &[felt_type], &[]),
@@ -474,7 +462,10 @@ fn func_def_op_res_name_round_trip() {
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "named_res",
         FunctionType::new(&context, &[], &[felt_type]),
@@ -497,7 +488,10 @@ fn func_def_op_def_with_signature_attrs_prints_named_arg_and_result() {
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def_with_signature_attrs(
+        &builder,
         loc,
         "named_signature",
         FunctionType::new(&context, &[felt_type], &[felt_type]),
@@ -507,10 +501,13 @@ fn func_def_op_def_with_signature_attrs_prints_named_arg_and_result() {
     )
     .unwrap();
 
-    let block = Block::new(&[(felt_type, loc)]);
+    let block = op
+        .body()
+        .unwrap()
+        .append_block(Block::new(&[(felt_type, loc)]));
     let arg: Value = block.argument(0).unwrap().into();
-    block.append_operation(dialect::function::r#return(loc, &[arg]));
-    op.region(0).unwrap().append_block(block);
+    builder.set_insertion_point_at_start(block);
+    dialect::function::r#return(&builder, loc, &[arg]);
 
     let ir = format!("{op}");
     assert!(ir.contains("{function.arg_name = \"input\"}"));
@@ -523,7 +520,10 @@ fn func_def_op_signature_name_accessors_return_out_of_bounds() {
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let module = llzk_module(loc, None);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "bounds",
         FunctionType::new(&context, &[felt_type], &[felt_type]),
@@ -556,7 +556,10 @@ fn func_def_op_arg_and_res_attrs_round_trip() {
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
     let op = dialect::function::def(
+        &builder,
         loc,
         "attrs_round_trip",
         FunctionType::new(&context, &[felt_type], &[felt_type]),

--- a/llzk/tests/pod_dialect.rs
+++ b/llzk/tests/pod_dialect.rs
@@ -1,7 +1,7 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for the pod dialect.
 
-use llzk::builder::{OpBuilder, OpBuilderLike};
+use llzk::builder::{OpBuilder, OpBuilderLike as _};
 use llzk::map_operands::MapOperandsBuilder;
 use llzk::prelude::melior_dialects::arith;
 use llzk::prelude::*;

--- a/llzk/tests/poly_dialect.rs
+++ b/llzk/tests/poly_dialect.rs
@@ -41,10 +41,12 @@ fn create_read_const() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
-    let op = dialect::poly::read_const(loc, "A", FeltType::new(&context).into());
+    let module = llzk_module(loc, None);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let op = dialect::poly::read_const(&builder, loc, "A", FeltType::new(&context).into());
 
     let ir = format!("{op}");
-    let expected = "%0 = poly.read_const @A : !felt.type\n";
+    let expected = "%0 = \"poly.read_const\"() <{const_name = @A}> : () -> !felt.type";
     assert_eq!(ir, expected);
     assert!(op.verify());
 }
@@ -54,10 +56,11 @@ fn is_read_const() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
-    let op = dialect::poly::read_const(loc, "C", IntegerType::new(&context, 64).into());
+    let module = llzk_module(loc, None);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let op = dialect::poly::read_const(&builder, loc, "C", IntegerType::new(&context, 64).into());
 
-    let op_ref = unsafe { OperationRef::from_raw(op.to_raw()) };
-    assert!(dialect::poly::is_read_const_op(&op_ref));
+    assert!(dialect::poly::is_read_const_op(&op));
 }
 
 #[test]
@@ -250,18 +253,11 @@ fn empty_struct_with_one_param() {
 
     let tmpl = template(&builder, loc, "tmpl", |builder| {
         param(builder, loc, "T", None)?;
-        builder.insert(loc, |_, loc| {
-            dialect::r#struct::def(
-                loc,
-                "empty",
-                [
-                    dialect::r#struct::helpers::compute_fn(loc, typ, &[], None).map(Into::into),
-                    dialect::r#struct::helpers::constrain_fn(loc, typ, &[], None).map(Into::into),
-                ],
-            )
-            .unwrap()
-            .into()
-        });
+        dialect::r#struct::def(builder, loc, "empty", |builder| {
+            dialect::r#struct::helpers::compute_fn(builder, loc, typ, &[], None)?;
+            dialect::r#struct::helpers::constrain_fn(builder, loc, typ, &[], None)?;
+            Ok(())
+        })?;
         Ok(())
     })
     .unwrap();
@@ -394,6 +390,7 @@ fn create_unifiable_cast() {
     let location = Location::unknown(&context);
     let module = llzk_module(location, None);
     let block = module.body();
+    let builder = OpBuilder::at_block_begin(&context, block);
 
     let affine_map_str = "affine_map<()[s0, s1] -> (s0 + s1)>";
     let affine_map =
@@ -403,18 +400,18 @@ fn create_unifiable_cast() {
         &[FlatSymbolRefAttribute::new(&context, "N").into()],
     );
     let array_op = dialect::array::new(
-        &OpBuilder::at_block_begin(&context, module.body()),
+        &builder,
         location,
         array_ty,
         llzk::dialect::array::ArrayCtor::Values(&[]),
     );
     let new_array_ty = ArrayType::new(FeltType::new(&context).into(), &[affine_map]);
     let cast = unifiable_cast(
+        &builder,
         location,
         array_op.result(0).unwrap().into(),
         new_array_ty.into(),
     );
-    let cast = block.append_operation(cast);
     assert!(cast.verify(), "op {cast} failed to verify");
     assert!(is_unifiable_cast_op(&cast));
 
@@ -670,7 +667,7 @@ fn const_binding_ops_empty_template() {
     let loc = Location::unknown(&context);
     let module = llzk_module(loc, None);
     let builder = OpBuilder::at_block_begin(&context, module.body());
-    let tmpl = template(&builder, loc, "empty", |_| Ok(())).unwrap();
+    let tmpl = template(&builder, loc, "empty", llzk::dialect::empty_region).unwrap();
     assert!(tmpl.const_binding_ops().is_empty());
     assert!(!tmpl.has_const_param_ops());
     assert!(!tmpl.has_const_expr_ops());

--- a/llzk/tests/struct_dialect.rs
+++ b/llzk/tests/struct_dialect.rs
@@ -1,25 +1,30 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for the struct dialect.
 
-use llzk::{builder::OpBuilder, prelude::*};
+use llzk::{
+    builder::{OpBuilder, OpBuilderLike},
+    prelude::*,
+};
 
 mod common;
 
 fn default_funcs<'c>(
+    builder: &impl OpBuilderLike<'c>,
     loc: Location<'c>,
     typ: StructType<'c>,
-) -> [Result<Operation<'c>, LlzkError>; 2] {
-    [
-        dialect::r#struct::helpers::compute_fn(loc, typ, &[], None).map(Into::into),
-        dialect::r#struct::helpers::constrain_fn(loc, typ, &[], None).map(Into::into),
-    ]
+) -> Result<(), LlzkError> {
+    dialect::r#struct::helpers::compute_fn(builder, loc, typ, &[], None)?;
+    dialect::r#struct::helpers::constrain_fn(builder, loc, typ, &[], None)?;
+    Ok(())
 }
 
 fn product_only_funcs<'c>(
+    builder: &impl OpBuilderLike<'c>,
     loc: Location<'c>,
     typ: StructType<'c>,
-) -> [Result<Operation<'c>, LlzkError>; 1] {
-    [dialect::r#struct::helpers::product_fn(loc, typ, &[], None).map(Into::into)]
+) -> Result<(), LlzkError> {
+    dialect::r#struct::helpers::product_fn(builder, loc, typ, &[], None)?;
+    Ok(())
 }
 
 #[test]
@@ -50,8 +55,11 @@ fn empty_struct() {
     let typ = StructType::from_str(&context, name);
     assert_eq!(typ.name().to_string(), format!("@{}", name));
 
-    let s = dialect::r#struct::def(loc, name, default_funcs(loc, typ)).unwrap();
-    let s = module.body().append_operation(s.into());
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let s = dialect::r#struct::def(&builder, loc, name, |builder| {
+        default_funcs(builder, loc, typ)
+    })
+    .unwrap();
 
     assert_test!(s, module, @file "expected/empty_struct.mlir" );
 }
@@ -66,16 +74,22 @@ fn struct_with_one_member() {
     let typ = StructType::from_str_params(&context, name, &[]);
     assert_eq!(typ.name().to_string(), format!("@{}", name));
 
-    let mut region_ops = vec![
-        dialect::r#struct::member(loc, "foo", Type::index(&context), false, false, false)
-            .map(Into::into),
-    ];
-    region_ops.extend(default_funcs(loc, typ));
-
-    let s = dialect::r#struct::def(loc, name, region_ops).unwrap();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let s = dialect::r#struct::def(&builder, loc, name, |builder| {
+        dialect::r#struct::member(
+            builder,
+            loc,
+            "foo",
+            Type::index(&context),
+            false,
+            false,
+            false,
+        )?;
+        default_funcs(builder, loc, typ)
+    })
+    .unwrap();
     assert!(s.find_member_def("foo").is_some());
     assert_eq!(s.member_defs().len(), 1);
-    let s = module.body().append_operation(s.into());
 
     assert_test!(s, module, @file "expected/struct_with_one_member.mlir");
 }
@@ -85,8 +99,18 @@ fn signal_column_and_public_member() {
     common::setup();
     let context = LlzkContext::new();
     let loc = Location::unknown(&context);
-    let member =
-        dialect::r#struct::member(loc, "foo", FeltType::new(&context), true, true, true).unwrap();
+    let module = Module::new(loc);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let member = dialect::r#struct::member(
+        &builder,
+        loc,
+        "foo",
+        FeltType::new(&context),
+        true,
+        true,
+        true,
+    )
+    .unwrap();
 
     assert!(member.signal());
     assert!(member.column());
@@ -118,26 +142,25 @@ fn empty_struct_with_pub_inputs() {
 
     let inputs = vec![(FeltType::new(&context).into(), Location::unknown(&context))];
     let arg_attrs = vec![vec![PublicAttribute::new_named_attr(&context)]];
-    let s = dialect::r#struct::def(loc, name, {
-        [
-            dialect::r#struct::helpers::compute_fn(
-                loc,
-                typ,
-                inputs.as_slice(),
-                Some(arg_attrs.as_slice()),
-            )
-            .map(Into::into),
-            dialect::r#struct::helpers::constrain_fn(
-                loc,
-                typ,
-                inputs.as_slice(),
-                Some(arg_attrs.as_slice()),
-            )
-            .map(Into::into),
-        ]
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let s = dialect::r#struct::def(&builder, loc, name, |builder| {
+        dialect::r#struct::helpers::compute_fn(
+            builder,
+            loc,
+            typ,
+            inputs.as_slice(),
+            Some(arg_attrs.as_slice()),
+        )?;
+        dialect::r#struct::helpers::constrain_fn(
+            builder,
+            loc,
+            typ,
+            inputs.as_slice(),
+            Some(arg_attrs.as_slice()),
+        )?;
+        Ok(())
     })
     .unwrap();
-    let s = module.body().append_operation(s.into());
 
     assert_test!(s, module, @file "expected/empty_struct_with_pub_inputs.mlir");
 }
@@ -151,20 +174,26 @@ fn struct_readm() {
     let loc = Location::unknown(&context);
     let typ = StructType::from_str_params(&context, name, &[]);
 
-    let mut region_ops = vec![
-        dialect::r#struct::member(loc, "foo", Type::index(&context), false, false, false)
-            .map(Into::into),
-    ];
-    region_ops.extend(default_funcs(loc, typ));
-
-    let s = dialect::r#struct::def(loc, name, region_ops).unwrap();
-    let s = StructDefOpRef::try_from(module.body().append_operation(s.into())).unwrap();
+    let module_builder = OpBuilder::at_block_begin(&context, module.body());
+    let s = dialect::r#struct::def(&module_builder, loc, name, |builder| {
+        dialect::r#struct::member(
+            builder,
+            loc,
+            "foo",
+            Type::index(&context),
+            false,
+            false,
+            false,
+        )?;
+        default_funcs(builder, loc, typ)
+    })
+    .unwrap();
 
     let constrain_body = s
         .constrain_func()
         .expect("failed to get constrain function")
-        .region(0)
-        .expect("failed to get first region")
+        .body()
+        .expect("failed to get body region")
         .first_block()
         .expect("failed to get first block");
 
@@ -180,6 +209,57 @@ fn struct_readm() {
 }
 
 #[test]
+fn struct_readm_with_literal_offset() {
+    common::setup();
+    let name = "read_member_offset";
+    let context = LlzkContext::new();
+    let module = llzk_module(Location::unknown(&context), None);
+    let loc = Location::unknown(&context);
+    let typ = StructType::from_str_params(&context, name, &[]);
+
+    let module_builder = OpBuilder::at_block_begin(&context, module.body());
+    let s = dialect::r#struct::def(&module_builder, loc, name, |builder| {
+        dialect::r#struct::member(
+            builder,
+            loc,
+            "foo",
+            Type::index(&context),
+            false,
+            true,
+            false,
+        )?;
+        default_funcs(builder, loc, typ)
+    })
+    .unwrap();
+
+    let constrain_body = s
+        .constrain_func()
+        .expect("failed to get constrain function")
+        .body()
+        .expect("failed to get body region")
+        .first_block()
+        .expect("failed to get first block");
+
+    let self_value: Value = constrain_body.argument(0).unwrap().into();
+    let builder = OpBuilder::new(
+        &context,
+        llzk::builder::EntryPoint::Before(constrain_body.terminator().unwrap()),
+    );
+    let readm_op = dialect::r#struct::readm_with_offset(
+        &builder,
+        loc,
+        Type::index(&context),
+        self_value,
+        "foo",
+        1,
+    )
+    .unwrap();
+
+    assert!(dialect::r#struct::is_struct_readm(&readm_op));
+    assert!(readm_op.verify());
+}
+
+#[test]
 fn product_only_struct_product_func() {
     common::setup();
     let name = "product_only";
@@ -188,8 +268,11 @@ fn product_only_struct_product_func() {
     let loc = Location::unknown(&context);
     let typ = StructType::from_str_params(&context, name, &[]);
 
-    let s = dialect::r#struct::def(loc, name, product_only_funcs(loc, typ)).unwrap();
-    let s = StructDefOpRef::try_from(module.body().append_operation(s.into())).unwrap();
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let s = dialect::r#struct::def(&builder, loc, name, |builder| {
+        product_only_funcs(builder, loc, typ)
+    })
+    .unwrap();
 
     assert!(s.compute_func().is_none());
     assert!(s.constrain_func().is_none());

--- a/llzk/tests/symbol_table.rs
+++ b/llzk/tests/symbol_table.rs
@@ -1,24 +1,30 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for symbol table behavior.
 
-use llzk::dialect;
 use llzk::dialect::module::llzk_module;
-use llzk::prelude::{BlockLike, FuncDefOp, FuncDefOpLike, FuncDefOpRef, FunctionType, LlzkContext};
+use llzk::prelude::{BlockLike, FuncDefOpLike as _, FuncDefOpRef, FunctionType, LlzkContext};
 use llzk::symbol_table;
-use melior::ir::Location;
+use llzk_sys::llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs;
+use melior::{
+    StringRef,
+    ir::{Location, Operation, TypeLike as _},
+};
 
 mod common;
 
 #[inline]
-fn make_empty_func<'c>(context: &'c LlzkContext, name: &str) -> FuncDefOp<'c> {
-    dialect::function::def(
-        Location::unknown(context),
-        name,
-        FunctionType::new(context, &[], &[]),
-        &[],
-        None,
-    )
-    .unwrap()
+fn make_empty_func<'c>(context: &'c LlzkContext, name: &str) -> Operation<'c> {
+    unsafe {
+        Operation::from_raw(llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
+            Location::unknown(context).to_raw(),
+            StringRef::new(name).to_raw(),
+            FunctionType::new(context, &[], &[]).to_raw(),
+            0,
+            std::ptr::null(),
+            0,
+            std::ptr::null(),
+        ))
+    }
 }
 
 #[test]
@@ -30,12 +36,12 @@ fn insert_renames_symbols_on_collision() {
     let first = FuncDefOpRef::try_from(
         module
             .body()
-            .append_operation(make_empty_func(&context, "foo").into()),
+            .append_operation(make_empty_func(&context, "foo")),
     )
     .unwrap();
 
     let module_op = module.as_operation();
-    let inserted = symbol_table::insert(&module_op, make_empty_func(&context, "foo").into());
+    let inserted = symbol_table::insert(&module_op, make_empty_func(&context, "foo"));
     let second = FuncDefOpRef::try_from(inserted).unwrap();
 
     assert_eq!(format!("{}", first.fully_qualified_name()), "@foo");

--- a/llzk/tests/symbol_table.rs
+++ b/llzk/tests/symbol_table.rs
@@ -3,49 +3,44 @@
 
 use llzk::builder::{OpBuilder, OpBuilderLike};
 use llzk::dialect::module::llzk_module;
-use llzk::prelude::{BlockLike, FuncDefOpLike as _, FuncDefOpRef, FunctionType, LlzkContext};
-use llzk::symbol_table;
-use llzk_sys::llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs;
-use melior::{
-    StringRef,
-    ir::{Location, Operation, TypeLike as _},
+use llzk::prelude::{
+    FuncDefOpLike as _, FuncDefOpRef, FunctionType, LlzkContext, Location, Operation, dialect,
 };
+use llzk::symbol_table;
 
 mod common;
 
 #[inline]
-fn make_empty_func<'c>(builder: &impl OpBuilderLike<'c>, name: &str) -> Operation<'c> {
-    let context = unsafe { builder.context().to_ref() };
-    unsafe {
-        Operation::from_raw(llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
-            builder.to_raw(),
-            Location::unknown(context).to_raw(),
-            StringRef::new(name).to_raw(),
-            FunctionType::new(context, &[], &[]).to_raw(),
-            0,
-            std::ptr::null(),
-            0,
-            std::ptr::null(),
-        ))
-    }
+fn make_empty_func<'c, 'a>(
+    builder: &impl OpBuilderLike<'c>,
+    context: &'c LlzkContext,
+    location: Location<'c>,
+    name: &str,
+) -> FuncDefOpRef<'c, 'a> {
+    dialect::function::def(
+        builder,
+        location,
+        name,
+        FunctionType::new(context, &[], &[]),
+        &[],
+        None,
+    )
+    .unwrap()
 }
 
 #[test]
 fn insert_renames_symbols_on_collision() {
     common::setup();
     let context = LlzkContext::new();
-    let module = llzk_module(Location::unknown(&context), None);
-    let builder = unsafe { OpBuilder::from_raw(llzk_sys::mlirOpBuilderCreate(context.to_raw())) };
+    let loc = Location::unknown(&context);
+    let module = llzk_module(loc, None);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
 
-    let first = FuncDefOpRef::try_from(
-        module
-            .body()
-            .append_operation(make_empty_func(&builder, "foo")),
-    )
-    .unwrap();
+    let first = make_empty_func(&builder, &context, loc, "foo");
+    let duplicate = unsafe { Operation::from_raw(llzk_sys::mlirOperationClone(first.to_raw())) };
 
     let module_op = module.as_operation();
-    let inserted = symbol_table::insert(&module_op, make_empty_func(&builder, "foo"));
+    let inserted = symbol_table::insert(&module_op, duplicate);
     let second = FuncDefOpRef::try_from(inserted).unwrap();
 
     assert_eq!(format!("{}", first.fully_qualified_name()), "@foo");

--- a/llzk/tests/symbol_table.rs
+++ b/llzk/tests/symbol_table.rs
@@ -24,6 +24,7 @@ fn make_empty_func<'c, 'a>(
         FunctionType::new(context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap()
 }

--- a/llzk/tests/symbol_table.rs
+++ b/llzk/tests/symbol_table.rs
@@ -1,10 +1,11 @@
 #![allow(unused_crate_dependencies)]
 //! Integration tests for symbol table behavior.
 
+use llzk::builder::{OpBuilder, OpBuilderLike};
 use llzk::dialect::module::llzk_module;
 use llzk::prelude::{BlockLike, FuncDefOpLike as _, FuncDefOpRef, FunctionType, LlzkContext};
 use llzk::symbol_table;
-use llzk_sys::llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs;
+use llzk_sys::llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs;
 use melior::{
     StringRef,
     ir::{Location, Operation, TypeLike as _},
@@ -13,9 +14,11 @@ use melior::{
 mod common;
 
 #[inline]
-fn make_empty_func<'c>(context: &'c LlzkContext, name: &str) -> Operation<'c> {
+fn make_empty_func<'c>(builder: &impl OpBuilderLike<'c>, name: &str) -> Operation<'c> {
+    let context = unsafe { builder.context().to_ref() };
     unsafe {
-        Operation::from_raw(llzkFunction_FuncDefOpCreateWithAttrsAndArgAttrs(
+        Operation::from_raw(llzkFunction_FuncDefOpBuildWithAttrsAndArgAttrs(
+            builder.to_raw(),
             Location::unknown(context).to_raw(),
             StringRef::new(name).to_raw(),
             FunctionType::new(context, &[], &[]).to_raw(),
@@ -32,16 +35,17 @@ fn insert_renames_symbols_on_collision() {
     common::setup();
     let context = LlzkContext::new();
     let module = llzk_module(Location::unknown(&context), None);
+    let builder = unsafe { OpBuilder::from_raw(llzk_sys::mlirOpBuilderCreate(context.to_raw())) };
 
     let first = FuncDefOpRef::try_from(
         module
             .body()
-            .append_operation(make_empty_func(&context, "foo")),
+            .append_operation(make_empty_func(&builder, "foo")),
     )
     .unwrap();
 
     let module_op = module.as_operation();
-    let inserted = symbol_table::insert(&module_op, make_empty_func(&context, "foo"));
+    let inserted = symbol_table::insert(&module_op, make_empty_func(&builder, "foo"));
     let second = FuncDefOpRef::try_from(inserted).unwrap();
 
     assert_eq!(format!("{}", first.fully_qualified_name()), "@foo");

--- a/llzk/tests/value_ext.rs
+++ b/llzk/tests/value_ext.rs
@@ -3,6 +3,7 @@
 
 use llzk::{
     attributes::array::AffineMapAttribute,
+    builder::{OpBuilder, OpBuilderLike as _},
     prelude::*,
     value_ext::{has_uses, replace_all_uses_in_block_with, users_of},
 };
@@ -20,13 +21,12 @@ fn replace_all_uses_in_block_with_handles_repeated_operands() {
     let orig = block.argument(0).unwrap();
     let replacement = block.argument(1).unwrap();
     let replacement_value: Value = replacement.into();
+    let builder = OpBuilder::at_block_begin(&context, &block);
 
-    let use_before = block
-        .append_operation(dialect::felt::mul(location, orig.into(), replacement_value).unwrap());
-    let repeated_use =
-        block.append_operation(dialect::felt::add(location, orig.into(), orig.into()).unwrap());
-    let use_after = block
-        .append_operation(dialect::felt::sub(location, orig.into(), replacement_value).unwrap());
+    let use_before =
+        dialect::felt::mul(&builder, location, orig.into(), replacement_value).unwrap();
+    let repeated_use = dialect::felt::add(&builder, location, orig.into(), orig.into()).unwrap();
+    let use_after = dialect::felt::sub(&builder, location, orig.into(), replacement_value).unwrap();
 
     replace_all_uses_in_block_with(orig.owner(), orig, replacement);
 
@@ -51,12 +51,11 @@ fn replace_all_uses_in_block_with_only_replaces_orig() {
     let untouched = block.argument(2).unwrap();
     let replacement_value: Value = replacement.into();
     let untouched_value: Value = untouched.into();
+    let builder = OpBuilder::at_block_begin(&context, &block);
 
-    let mixed_use = block
-        .append_operation(dialect::felt::add(location, orig.into(), untouched.into()).unwrap());
-    let non_orig_use = block.append_operation(
-        dialect::felt::mul(location, untouched.into(), replacement.into()).unwrap(),
-    );
+    let mixed_use = dialect::felt::add(&builder, location, orig.into(), untouched.into()).unwrap();
+    let non_orig_use =
+        dialect::felt::mul(&builder, location, untouched.into(), replacement.into()).unwrap();
 
     replace_all_uses_in_block_with(orig.owner(), orig, replacement);
 
@@ -95,7 +94,8 @@ fn users_of_returns_single_user() {
     let felt_type: Type = FeltType::new(&context).into();
     let block = Block::new(&[(felt_type, location)]);
     let arg = block.argument(0).unwrap();
-    block.append_operation(dialect::felt::neg(location, arg.into()).unwrap());
+    let builder = OpBuilder::at_block_begin(&context, &block);
+    dialect::felt::neg(&builder, location, arg.into()).unwrap();
     let users = users_of(arg);
     assert_eq!(users.len(), 1);
 }
@@ -108,8 +108,9 @@ fn users_of_returns_multiple_users() {
     let felt_type: Type = FeltType::new(&context).into();
     let block = Block::new(&[(felt_type, location)]);
     let arg: Value = block.argument(0).unwrap().into();
-    block.append_operation(dialect::felt::neg(location, arg).unwrap());
-    block.append_operation(dialect::felt::inv(location, arg).unwrap());
+    let builder = OpBuilder::at_block_begin(&context, &block);
+    dialect::felt::neg(&builder, location, arg).unwrap();
+    dialect::felt::inv(&builder, location, arg).unwrap();
     let users = users_of(arg);
     assert_eq!(users.len(), 2);
 }
@@ -124,7 +125,8 @@ fn print_operation_does_not_panic() {
     let felt_type: Type = FeltType::new(&context).into();
     let block = Block::new(&[(felt_type, location)]);
     let arg: Value = block.argument(0).unwrap().into();
-    let op = block.append_operation(dialect::felt::neg(location, arg).unwrap());
+    let builder = OpBuilder::at_block_begin(&context, &block);
+    let op = dialect::felt::neg(&builder, location, arg).unwrap();
     print_operation(&op);
 }
 
@@ -136,7 +138,8 @@ fn print_block_does_not_panic() {
     let felt_type: Type = FeltType::new(&context).into();
     let block = Block::new(&[(felt_type, location)]);
     let arg: Value = block.argument(0).unwrap().into();
-    block.append_operation(dialect::felt::neg(location, arg).unwrap());
+    let builder = OpBuilder::at_block_begin(&context, &block);
+    dialect::felt::neg(&builder, location, arg).unwrap();
     print_block(&block);
 }
 
@@ -147,13 +150,15 @@ fn print_region_does_not_panic() {
     let location = Location::unknown(&context);
     let felt_type: Type = FeltType::new(&context).into();
     let func_type = melior::ir::r#type::FunctionType::new(&context, &[felt_type], &[]);
-    let func = dialect::function::def(location, "test_fn", func_type, &[], None).unwrap();
-    let block = Block::new(&[(felt_type, location)]);
+    let module = Module::new(location);
+    let builder = OpBuilder::at_block_begin(&context, module.body());
+    let func = dialect::function::def(&builder, location, "test_fn", func_type, &[], None).unwrap();
+    let region = func.body().expect("function must have a body");
+    let block = region.append_block(Block::new(&[(felt_type, location)]));
     let arg: Value = block.argument(0).unwrap().into();
-    block.append_operation(dialect::felt::neg(location, arg).unwrap());
-    block.append_operation(dialect::function::r#return(location, &[]));
-    let region = func.region(0).expect("function must have a region");
-    region.append_block(block);
+    builder.set_insertion_point_at_start(block);
+    dialect::felt::neg(&builder, location, arg).unwrap();
+    dialect::function::r#return(&builder, location, &[]);
     print_region(&region);
 }
 

--- a/llzk/tests/value_ext.rs
+++ b/llzk/tests/value_ext.rs
@@ -152,9 +152,20 @@ fn print_region_does_not_panic() {
     let func_type = melior::ir::r#type::FunctionType::new(&context, &[felt_type], &[]);
     let module = Module::new(location);
     let builder = OpBuilder::at_block_begin(&context, module.body());
-    let func = dialect::function::def(&builder, location, "test_fn", func_type, &[], None).unwrap();
+    let func = dialect::function::def(
+        &builder,
+        location,
+        "test_fn",
+        func_type,
+        &[],
+        None,
+        llzk::dialect::empty_region,
+    )
+    .unwrap();
     let region = func.body().expect("function must have a body");
-    let block = region.append_block(Block::new(&[(felt_type, location)]));
+    let block = region
+        .first_block()
+        .expect("function must have an entry block");
     let arg: Value = block.argument(0).unwrap().into();
     builder.set_insertion_point_at_start(block);
     dialect::felt::neg(&builder, location, arg).unwrap();

--- a/llzk/tests/verif_dialect.rs
+++ b/llzk/tests/verif_dialect.rs
@@ -31,14 +31,14 @@ fn make_function_target<'c>(
         FunctionType::new(context, &[felt_type], &[felt_type]),
         &[],
         arg_attrs,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
-        let block = Block::new(&[(felt_type, loc)]);
+        let block = func.body().unwrap().first_block().unwrap();
         let arg: Value = block.argument(0).unwrap().into();
-        let builder = OpBuilder::at_block_begin(context, &block);
+        let builder = OpBuilder::at_block_begin(context, block);
         dialect::function::r#return(&builder, loc, &[arg]);
-        func.body().unwrap().append_block(block);
     }
     func
 }
@@ -57,13 +57,13 @@ fn make_zero_arg_function_target<'c>(
         FunctionType::new(context, &[], &[]),
         &[],
         None,
+        llzk::dialect::empty_region,
     )
     .unwrap();
     {
-        let block = Block::new(&[]);
-        let builder = OpBuilder::at_block_begin(context, &block);
+        let block = func.body().unwrap().first_block().unwrap();
+        let builder = OpBuilder::at_block_begin(context, block);
         dialect::function::r#return(&builder, loc, &[]);
-        func.body().unwrap().append_block(block);
     }
     func
 }

--- a/llzk/tests/verif_dialect.rs
+++ b/llzk/tests/verif_dialect.rs
@@ -3,7 +3,7 @@
 
 use llzk::{
     attributes::NamedAttribute,
-    builder::{OpBuilder, OpBuilderLike},
+    builder::{OpBuilder, OpBuilderLike as _},
     prelude::*,
     value_ext::{OwningValueRange, ValueRange},
 };
@@ -23,7 +23,9 @@ fn make_function_target<'c>(
 ) -> FuncDefOpRef<'c, 'c> {
     let loc = Location::unknown(context);
     let felt_type: Type = FeltType::new(context).into();
+    let builder = OpBuilder::at_block_end(context, module.body());
     let func = dialect::function::def(
+        &builder,
         loc,
         name,
         FunctionType::new(context, &[felt_type], &[felt_type]),
@@ -34,10 +36,11 @@ fn make_function_target<'c>(
     {
         let block = Block::new(&[(felt_type, loc)]);
         let arg: Value = block.argument(0).unwrap().into();
-        block.append_operation(dialect::function::r#return(loc, &[arg]));
-        func.region(0).unwrap().append_block(block);
+        let builder = OpBuilder::at_block_begin(context, &block);
+        dialect::function::r#return(&builder, loc, &[arg]);
+        func.body().unwrap().append_block(block);
     }
-    FuncDefOpRef::try_from(module.body().append_operation(func.into())).unwrap()
+    func
 }
 
 fn make_zero_arg_function_target<'c>(
@@ -46,14 +49,23 @@ fn make_zero_arg_function_target<'c>(
     name: &str,
 ) -> FuncDefOpRef<'c, 'c> {
     let loc = Location::unknown(context);
-    let func =
-        dialect::function::def(loc, name, FunctionType::new(context, &[], &[]), &[], None).unwrap();
+    let builder = OpBuilder::at_block_end(context, module.body());
+    let func = dialect::function::def(
+        &builder,
+        loc,
+        name,
+        FunctionType::new(context, &[], &[]),
+        &[],
+        None,
+    )
+    .unwrap();
     {
         let block = Block::new(&[]);
-        block.append_operation(dialect::function::r#return(loc, &[]));
-        func.region(0).unwrap().append_block(block);
+        let builder = OpBuilder::at_block_begin(context, &block);
+        dialect::function::r#return(&builder, loc, &[]);
+        func.body().unwrap().append_block(block);
     }
-    FuncDefOpRef::try_from(module.body().append_operation(func.into())).unwrap()
+    func
 }
 
 fn make_struct_target<'c>(
@@ -66,12 +78,13 @@ fn make_struct_target<'c>(
     let typ = StructType::from_str_params(context, name, &[]);
     let felt_type: Type = FeltType::new(context).into();
     let inputs = [(felt_type, loc)];
-    let ops = [
-        dialect::r#struct::helpers::compute_fn(loc, typ, &inputs, arg_attrs).map(Into::into),
-        dialect::r#struct::helpers::constrain_fn(loc, typ, &inputs, arg_attrs).map(Into::into),
-    ];
-    let strukt = dialect::r#struct::def(loc, name, ops).unwrap();
-    StructDefOpRef::try_from(module.body().append_operation(strukt.into())).unwrap()
+    let builder = OpBuilder::at_block_end(context, module.body());
+    dialect::r#struct::def(&builder, loc, name, |builder| {
+        dialect::r#struct::helpers::compute_fn(builder, loc, typ, &inputs, arg_attrs)?;
+        dialect::r#struct::helpers::constrain_fn(builder, loc, typ, &inputs, arg_attrs)?;
+        Ok(())
+    })
+    .unwrap()
 }
 
 fn bool_constant<'c>(context: &'c LlzkContext, value: bool) -> Operation<'c> {


### PR DESCRIPTION
This PR standardizes all op builders to directly call the CAPI build functions, ensuring the op is inserted and a ref is returned.

The "TODO" in `function::def` is blocked by https://github.com/project-llzk/llzk-lib/pull/620