### PR TITLE
Fix double-free when erasing operation

### DIFF
--- a/llzk/src/operation.rs
+++ b/llzk/src/operation.rs
@@ -244,7 +244,7 @@ pub fn build_owned_operation<'c, E>(
 /// Detach the given operation from its parent block, then erase it.
 #[inline]
 pub fn detach_and_erase_op<'c: 'a, 'a>(op: impl OperationRefLike<'c, 'a>) {
-    erase_op(detach_owned_operation(op));
+    drop(detach_owned_operation(op));
 }
 
 /// Return `true` iff the given op is has the given name.


### PR DESCRIPTION
The `detach_and_erase_op` had a double-free bug because it was using `detach_owned_operation` for detaching an operation into an owned `Operation` and then manually removing it with `erase_op`. The operation would then get double-freed when the `Operation` is dropped.  
